### PR TITLE
docs: clarify DB client step is required, not optional

### DIFF
--- a/BUILD1.md
+++ b/BUILD1.md
@@ -111,12 +111,22 @@ the comment at the top of `build-mac-extras.sh` for details.
 
 ---
 
-### 7. Bake in database client libraries (optional but recommended)
+### 7. Bake in database client libraries
 
-Skipping this step is safe — the database driver bundles will still build and
-load, but end-users will need a PostgreSQL or MySQL client installed on their
-own machine to make connections. Running it bakes the libraries in statically
-so no user-side installation is required.
+Required for functional DB drivers. The default prebuilts from step 6 are
+720-byte stub archives — enough for the linker to succeed, but the driver
+bundles end up with unresolved `PQconnectdb` / `mysql_init` symbols.
+
+- `dbmysql` has a `dlsym(RTLD_DEFAULT, "mysql_init")` guard and returns a
+  clean error if you skip this step
+  (`revdb/src/mysql_connection.cpp:37-50`).
+- `dbpostgresql` has no such guard — calling any PostgreSQL function on a
+  build that skipped this step crashes the engine.
+
+The first two scripts replace the stubs in `prebuilt/lib/mac/` with real
+static libraries from Homebrew, so step 8's `make compile-mac` links the
+bundles against them. The `rebuild-db*.sh` calls only matter when re-baking
+after an existing build; on a fresh tree, step 8 alone is enough.
 
 ```bash
 brew install libpq mysql-client


### PR DESCRIPTION
## Summary

BUILD1.md step 7 was labelled "optional but recommended" with text saying the build is safe to skip it. That's only half true:

- `dbmysql` has a `dlsym(RTLD_DEFAULT, "mysql_init")` guard in `revdb/src/mysql_connection.cpp:37-50` that returns a clean error if MySQL isn't loaded, so skipping step 7 is genuinely safe there.
- `dbpostgresql` has no such guard — calling any PostgreSQL script function on a build that skipped step 7 crashes the engine.

So I dropped the "optional" label and rewrote the explanation. Also clarified that the `rebuild-db*.sh` calls in the command block only matter when re-baking after an existing build — on a fresh tree, step 8 alone suffices.

Progress on #67.

## Test plan

- [ ] Read through — the flow still reads linearly.
- [ ] Code refs (`mysql_connection.cpp:37-50`) point at the right lines.