### PR TITLE
build-mac-extras: finish ICU removal + fix LIBZIP_BUILD orphan

### DIFF
--- a/BUILD1.md
+++ b/BUILD1.md
@@ -102,8 +102,8 @@ pass. Source is fetched to `prebuilt/build/icu-58-mac-arm64/` (gitignored).
 
 ### 6. Populate the remaining prebuilts
 
-libgif, libjpeg, libpng, libpcre, libzip, libcustomcrypto/ssl, and the
-stub libpq/libmysql archives.
+libgif, libjpeg, libpng, libpcre, libcustomcrypto/ssl, and the stub
+libpq/libmysql archives.
 
 ```bash
 brew install openssl@3     # if not already installed

--- a/prebuilt/scripts/build-mac-extras.sh
+++ b/prebuilt/scripts/build-mac-extras.sh
@@ -14,10 +14,6 @@
 #
 # Then this script:
 #   - Builds libgif/libjpeg/libpng/libpcre via xcodebuild and installs them
-#   - Compiles libzip 1.10.1 manually from the CMakeLists source list
-#     (the generated libzip.xcodeproj file list is stale and can't build
-#     cleanly against the modern libzip source; see the 'build-mac: prefer
-#     libzip src/ over include/' commit for context)
 #   - Supplies libcustomcrypto.a / libcustomssl.a from Homebrew openssl@3
 #     (engine now targets the 3.x symbol names directly; no compat shim)
 #   - Writes empty stub libpq.a and libmysql.a so the dbpostgresql /
@@ -56,18 +52,7 @@ for LIB in libgif libjpeg libpng libpcre; do
     cp "${DEBUG_OUT}/${LIB}.a" "${PREBUILT_LIB}/${LIB}.a"
 done
 
-# ── 2. ICU static libs (from build-icupkg-mac-arm64.sh output) ───────────────
-ICU_INSTALL="/tmp/icu58_arm64_build/icu_install"
-echo "=== Installing ICU static libs from ${ICU_INSTALL} ==="
-if [ ! -d "${ICU_INSTALL}/lib" ]; then
-    echo "ERROR: ${ICU_INSTALL}/lib not found — run prebuilt/scripts/build-icupkg-mac-arm64.sh first"
-    exit 1
-fi
-for f in libicudata.a libicui18n.a libicuio.a libicutu.a libicuuc.a; do
-    cp "${ICU_INSTALL}/lib/$f" "${PREBUILT_LIB}/$f"
-done
-
-# ── 3. libcustomcrypto / libcustomssl from Homebrew openssl@3 + compat shim ──
+# ── 2. libcustomcrypto / libcustomssl from Homebrew openssl@3 ────────────────
 echo "=== Supplying libcustomcrypto/libcustomssl from Homebrew openssl@3 ==="
 OPENSSL_PREFIX="$(brew --prefix openssl@3 2>/dev/null || true)"
 if [ -z "${OPENSSL_PREFIX}" ] || [ ! -f "${OPENSSL_PREFIX}/lib/libcrypto.a" ]; then
@@ -77,7 +62,7 @@ fi
 cp "${OPENSSL_PREFIX}/lib/libcrypto.a" "${PREBUILT_LIB}/libcustomcrypto.a"
 cp "${OPENSSL_PREFIX}/lib/libssl.a"    "${PREBUILT_LIB}/libcustomssl.a"
 
-# ── 4. Stub libpq.a and libmysql.a ───────────────────────────────────────────
+# ── 3. Stub libpq.a and libmysql.a ───────────────────────────────────────────
 # dbpostgresql.bundle and dbmysql.dylib link with -undefined dynamic_lookup
 # so unresolved symbols are deferred to load time. The linker still insists
 # on being able to find -lpq and -lmysql as files, so provide minimal
@@ -85,14 +70,16 @@ cp "${OPENSSL_PREFIX}/lib/libssl.a"    "${PREBUILT_LIB}/libcustomssl.a"
 # use these database drivers — install real libpq / libmysqlclient and
 # replace these if you need that functionality.
 echo "=== Creating stub libpq.a and libmysql.a ==="
-STUB_C="${LIBZIP_BUILD}/db-driver-stub.c"
+STUB_DIR="/tmp/hxt-mac-extras"
+mkdir -p "${STUB_DIR}"
+STUB_C="${STUB_DIR}/db-driver-stub.c"
 cat > "${STUB_C}" <<'EOF'
 /* Stub archive marker for dbpostgresql / dbmysql link-time satisfaction.
  * These drivers actually resolve symbols at dlopen time; see
  * prebuilt/scripts/build-mac-extras.sh for context. */
 int _hxt_db_driver_stub(void) { return 0; }
 EOF
-STUB_O="${LIBZIP_BUILD}/db-driver-stub.o"
+STUB_O="${STUB_DIR}/db-driver-stub.o"
 clang -arch arm64 -c "${STUB_C}" -o "${STUB_O}"
 ar rcs "${PREBUILT_LIB}/libpq.a"    "${STUB_O}"
 ar rcs "${PREBUILT_LIB}/libmysql.a" "${STUB_O}"


### PR DESCRIPTION
Two small follow-ups landing together because they're in the same script.

### 1. Finish the ICU removal #70 intended

PR #70 was supposed to drop the ICU-copy section of `build-mac-extras.sh` because `build-icu-mac-arm64.sh` now installs the libs directly. The merge conflict resolution kept the old section, so the script still reads from `/tmp/icu58_arm64_build/icu_install/lib/` — a path the new ICU script no longer populates (it installs to `prebuilt/build/icu-58-mac-arm64/`). On a fresh tree the script aborts with the old "run build-icupkg… first" error even after running the new build-icu script.

### 2. Fix `LIBZIP_BUILD` orphan reference from #69

#69 removed the libzip manual build block that defined `LIBZIP_BUILD`, but the stub section two blocks below still references it:

```bash
STUB_C="${LIBZIP_BUILD}/db-driver-stub.c"   # expands to "/db-driver-stub.c"
```

On a fresh tree the script tries to write the stub C file to the filesystem root and fails with permission denied. Replaced with a dedicated `STUB_DIR="/tmp/hxt-mac-extras"` local to the stub section.

### Also

- Drops the stale "Compiles libzip 1.10.1 manually" bullet from the top comment.
- Renumbers section headers (was 1/2/3/4, now 1/2/3 after the ICU drop).
- Trims `libzip` out of BUILD1.md section 6's list of what the extras script produces (libzip is built via gyp now).

## Test plan

- [x] `bash -n prebuilt/scripts/build-mac-extras.sh` clean.
- [x] Fresh run on macOS arm64: script completes; stub archives written to `prebuilt/lib/mac/libpq.a` + `libmysql.a` with the `_hxt_db_driver_stub` symbol.
- [x] No references to `/tmp/icu58_arm64_build/` or `${LIBZIP_BUILD}` remain.