### PR TITLE
make prebuilt-mac: one-command macOS arm64 prebuilts

### DIFF
--- a/BUILD1.md
+++ b/BUILD1.md
@@ -2,13 +2,13 @@
 
 ## Prerequisites
 
-1. **Clone location** — the repo must live at `~/Developer/HyperXTalk`.  
+1. **Clone location** — the repo must live at `~/Developer/HyperXTalk`.
    Create the folder if needed:
    ```bash
    mkdir -p ~/Developer
    git clone https://github.com/emily-elizabeth/HyperXTalk ~/Developer/HyperXTalk
    ```
-   > ⚠️ Do **not** clone into `~/Documents/` or any folder synced by iCloud Drive.  
+   > ⚠️ Do **not** clone into `~/Documents/` or any folder synced by iCloud Drive.
    > iCloud tags app bundles with extended attributes that break code signing.
 
 2. **Xcode** — ensure you have the latest version installed and have accepted the license:
@@ -16,11 +16,10 @@
    sudo xcodebuild -license accept
    ```
 
-3. **Homebrew** — required for `libffi`.  
-   Install: https://docs.brew.sh/Installation  
-   If already installed, update it:
+3. **Homebrew** — install from https://docs.brew.sh/Installation, then install
+   the formulae the prebuild scripts need:
    ```bash
-   brew upgrade
+   brew install openssl@3 libpq mysql-client
    ```
 
 4. **Python 3** — verify it is available:
@@ -30,132 +29,62 @@
 
 ---
 
-## Build Steps
+## Build
 
-Open Terminal and run the following commands in order.  
-All commands assume you are in the repo root — start every session with:
+From the repo root:
 
 ```bash
 cd ~/Developer/HyperXTalk
+make prebuilt-mac    # builds libffi, libskia & friends, libz, ICU, openssl
+                     #   extras, libpq, libmysql — about 10 min on an M1
+make compile-mac
 ```
 
----
+> ⚠️ `make compile-mac` ends with a code signing error on the very last line.
+> This is expected — look for `** BUILD SUCCEEDED **` just above it.
+> The signing step that follows handles it correctly.
 
-### 1. Build libffi
+### What `make prebuilt-mac` does
 
-```bash
-sh prebuilt/scripts/build-libffi-mac-arm64.sh
-```
+In order:
 
----
+1. `prebuilt/scripts/build-libffi-mac-arm64.sh` — vendored libffi → `prebuilt/lib/mac/libffi.a`.
+2. `prebuilt/scripts/build-thirdparty-mac-arm64.sh` — xcodebuild over the seven
+   vendored libs (libskia, libsqlite, libxml, libzip, libcairo, libxslt,
+   libiodbc) and copies the resulting `.a` files into `prebuilt/lib/mac/`.
+3. `prebuilt/scripts/build-libz-mac-arm64.sh` — zlib.
+4. `prebuilt/scripts/build-icu-mac-arm64.sh` — ICU 58.2 (icupkg host tool + five
+   `libicu*.a` static libs in one pass).
+5. `prebuilt/scripts/build-mac-extras.sh` — libgif, libjpeg, libpng, libpcre,
+   and `libcustomcrypto`/`libcustomssl` (copied from Homebrew openssl@3).
+6. `prebuilt/scripts/build-libpq-mac-arm64.sh` — real static libpq from Homebrew.
+7. `prebuilt/scripts/build-libmysql-mac-arm64.sh` — real static libmysqlclient.
 
-### 2. Build third-party libraries
+Step 6+7 replace the stub `libpq.a` / `libmysql.a` archives so that the
+`dbpostgresql` / `dbmysql` driver bundles link against functional
+client libraries. Without them, `dbpostgresql` silently crashes the engine
+when used (no runtime guard); `dbmysql` has a `dlsym` guard and reports a
+clean error (`revdb/src/mysql_connection.cpp:37-50`).
 
-```bash
-REPO=~/Developer/HyperXTalk
-for LIB in libskia libsqlite libxml libzip libcairo libxslt libiodbc; do
-  echo "=== Building $LIB ==="
-  xcodebuild \
-    -project "$REPO/build-mac/livecode/thirdparty/$LIB/$LIB.xcodeproj" \
-    -configuration Debug \
-    -arch arm64 \
-    SOLUTION_DIR="$REPO" 2>&1 | grep -E "BUILD (SUCCEEDED|FAILED)|error:"
-done
-```
+Re-running is idempotent — each script checks existing state and skips
+network work when it can.
 
----
+### Re-baking DB drivers after an existing build
 
-### 3. Build libz
-
-```bash
-sh prebuilt/scripts/build-libz-mac-arm64.sh
-```
-
----
-
-### 4. Copy libraries into place
+If you already have a built tree and want to replace the stub-linked
+driver bundles, use the rebuild scripts:
 
 ```bash
-REPO=~/Developer/HyperXTalk
-cp "$REPO/_build/mac/Debug/libcairo.a"  "$REPO/prebuilt/lib/mac/libcairo.a"
-cp "$REPO/_build/mac/Debug/libxslt.a"   "$REPO/prebuilt/lib/mac/libxslt.a"
-cp "$REPO/_build/mac/Debug/libiodbc.a"  "$REPO/prebuilt/lib/mac/libiodbc.a"
-for F in "$REPO"/_build/mac/Debug/libskia*.a; do
-  cp "$F" "$REPO/prebuilt/lib/mac/$(basename "$F")"
-done
-cp "$REPO/_build/mac/Debug/libxml.a"    "$REPO/prebuilt/lib/mac/libxml.a"
-cp "$REPO/_build/mac/Debug/libzip.a"    "$REPO/prebuilt/lib/mac/libzip.a"
-```
-
----
-
-### 5. Build ICU for arm64 macOS (icupkg host tool + five static libs)
-
-```bash
-sh prebuilt/scripts/build-icu-mac-arm64.sh
-```
-
-Produces `prebuilt/bin/mac/icupkg` and `prebuilt/lib/mac/libicu*.a` in one
-pass. Source is fetched to `prebuilt/build/icu-58-mac-arm64/` (gitignored).
-
----
-
-### 6. Populate the remaining prebuilts
-
-libgif, libjpeg, libpng, libpcre, libcustomcrypto/ssl, and the stub
-libpq/libmysql archives.
-
-```bash
-brew install openssl@3     # if not already installed
-sh prebuilt/scripts/build-mac-extras.sh
-```
-
-This script works around several things the upstream fetch-mac step
-was supposed to handle but no longer does (broken prebuilt URL). See
-the comment at the top of `build-mac-extras.sh` for details.
-
----
-
-### 7. Bake in database client libraries
-
-Required for functional DB drivers. The default prebuilts from step 6 are
-720-byte stub archives — enough for the linker to succeed, but the driver
-bundles end up with unresolved `PQconnectdb` / `mysql_init` symbols.
-
-- `dbmysql` has a `dlsym(RTLD_DEFAULT, "mysql_init")` guard and returns a
-  clean error if you skip this step
-  (`revdb/src/mysql_connection.cpp:37-50`).
-- `dbpostgresql` has no such guard — calling any PostgreSQL function on a
-  build that skipped this step crashes the engine.
-
-The first two scripts replace the stubs in `prebuilt/lib/mac/` with real
-static libraries from Homebrew, so step 8's `make compile-mac` links the
-bundles against them. The `rebuild-db*.sh` calls only matter when re-baking
-after an existing build; on a fresh tree, step 8 alone is enough.
-
-```bash
-brew install libpq mysql-client
-sh prebuilt/scripts/build-libpq-mac-arm64.sh
-sh prebuilt/scripts/build-libmysql-mac-arm64.sh
 sh rebuild-dbpostgresql.sh
 sh rebuild-dbmysql.sh
 ```
 
----
-
-### 8. Build the engine
-
-```bash
-make compile-mac
-```
-
-> ⚠️ The build will end with a code signing error on the very last line.  
-> This is expected — look for `** BUILD SUCCEEDED **` just above it.  
-> The signing step that follows will handle this correctly.
+On a fresh tree, `make compile-mac` alone is enough — the drivers link
+against the real libraries from `make prebuilt-mac` directly.
 
 ---
 
-### 9. Code sign mac-bin
+### Code sign `mac-bin`
 
 ```bash
 REPO=~/Developer/HyperXTalk
@@ -169,4 +98,3 @@ find "$MACBIN" -name "*.app" -exec codesign --force --options runtime \
   --entitlements "$REPO/HyperXTalk.entitlements" --sign - {} \;
 echo "Done signing."
 ```
-

--- a/Makefile.Mac
+++ b/Makefile.Mac
@@ -5,6 +5,28 @@
 # Prettifying output for CI builds
 XCODEBUILD_FILTER ?=
 
+# Build all macOS arm64 prebuilt dependencies in one pass.
+# Replaces the 7-step manual ritual previously documented in BUILD1.md.
+# Requires Homebrew prereqs: openssl@3, libpq, mysql-client.
+prebuilt-mac:
+	@echo "=== Verifying Homebrew prereqs ==="
+	@for formula in openssl@3 libpq mysql-client; do \
+	  if ! brew --prefix $$formula >/dev/null 2>&1; then \
+	    echo "ERROR: Homebrew formula '$$formula' not installed."; \
+	    echo "  Run: brew install openssl@3 libpq mysql-client"; \
+	    exit 1; \
+	  fi; \
+	done
+	sh prebuilt/scripts/build-libffi-mac-arm64.sh
+	sh prebuilt/scripts/build-thirdparty-mac-arm64.sh
+	sh prebuilt/scripts/build-libz-mac-arm64.sh
+	sh prebuilt/scripts/build-icu-mac-arm64.sh
+	sh prebuilt/scripts/build-mac-extras.sh
+	sh prebuilt/scripts/build-libpq-mac-arm64.sh
+	sh prebuilt/scripts/build-libmysql-mac-arm64.sh
+	@echo ""
+	@echo "=== prebuilt-mac: done. Next: make compile-mac ==="
+
 config-mac:
 ifneq ($(TRAVIS),undefined)
 	@echo "travis_fold:start:config"

--- a/prebuilt/scripts/build-thirdparty-mac-arm64.sh
+++ b/prebuilt/scripts/build-thirdparty-mac-arm64.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+# Build the seven vendored thirdparty libraries that have working xcodeprojs
+# (libskia libsqlite libxml libzip libcairo libxslt libiodbc) and copy their
+# .a outputs from _build/mac/Debug/ into prebuilt/lib/mac/.
+#
+# Extracted from BUILD1.md steps 2 + 4 so `make prebuilt-mac` can call a
+# single script instead of embedding the loop in the Makefile.
+#
+# Usage (from repo root):
+#   sh prebuilt/scripts/build-thirdparty-mac-arm64.sh
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+
+BUILD_OUT="${REPO_ROOT}/_build/mac/Debug"
+PREBUILT_LIB="${REPO_ROOT}/prebuilt/lib/mac"
+
+mkdir -p "${PREBUILT_LIB}"
+
+LIBS="libskia libsqlite libxml libzip libcairo libxslt libiodbc"
+
+for LIB in ${LIBS}; do
+    echo "=== Building ${LIB} ==="
+    xcodebuild \
+        -project "${REPO_ROOT}/build-mac/livecode/thirdparty/${LIB}/${LIB}.xcodeproj" \
+        -configuration Debug \
+        -arch arm64 \
+        SOLUTION_DIR="${REPO_ROOT}" \
+        2>&1 | grep -E "BUILD (SUCCEEDED|FAILED)|error:" || true
+done
+
+echo ""
+echo "=== Copying outputs into prebuilt/lib/mac ==="
+cp "${BUILD_OUT}/libcairo.a"  "${PREBUILT_LIB}/libcairo.a"
+cp "${BUILD_OUT}/libxslt.a"   "${PREBUILT_LIB}/libxslt.a"
+cp "${BUILD_OUT}/libiodbc.a"  "${PREBUILT_LIB}/libiodbc.a"
+cp "${BUILD_OUT}/libxml.a"    "${PREBUILT_LIB}/libxml.a"
+cp "${BUILD_OUT}/libzip.a"    "${PREBUILT_LIB}/libzip.a"
+cp "${BUILD_OUT}/libsqlite.a" "${PREBUILT_LIB}/libsqlite.a"
+for F in "${BUILD_OUT}"/libskia*.a; do
+    cp "$F" "${PREBUILT_LIB}/$(basename "$F")"
+done
+
+echo ""
+echo "=== Done. prebuilt/lib/mac now has: ==="
+ls "${PREBUILT_LIB}/" | sort


### PR DESCRIPTION
Last open item on #67's macOS hack list: `fetch-libraries.sh` bitrotted away and the 7-step BUILD1.md ritual replaced it. This collapses those steps into one `make prebuilt-mac`.

## Before

```bash
sh prebuilt/scripts/build-libffi-mac-arm64.sh
for LIB in libskia libsqlite libxml libzip libcairo libxslt libiodbc; do
  xcodebuild -project ... $LIB.xcodeproj ...
done
sh prebuilt/scripts/build-libz-mac-arm64.sh
cp _build/mac/Debug/libcairo.a prebuilt/lib/mac/   # x7
sh prebuilt/scripts/build-icu-mac-arm64.sh
sh prebuilt/scripts/build-mac-extras.sh
brew install libpq mysql-client
sh prebuilt/scripts/build-libpq-mac-arm64.sh
sh prebuilt/scripts/build-libmysql-mac-arm64.sh
make compile-mac
```

## After

```bash
brew install openssl@3 libpq mysql-client
make prebuilt-mac
make compile-mac
```

## What's in here

- **`Makefile.Mac`**: new `prebuilt-mac` target that sequences the seven per-library scripts. Starts with a fast-fail check that the three required Homebrew formulae are installed, so users get `ERROR: Homebrew formula 'libpq' not installed` up front instead of partway through a 10-minute build.
- **`prebuilt/scripts/build-thirdparty-mac-arm64.sh`** (new, 48 lines): extracts the inline xcodebuild loop + cp step that BUILD1.md used to embed. No behaviour change, just moved out of markdown so the make target can call one script instead of inlining bash.
- **`BUILD1.md`** (-111 / +61): rewrites prerequisites + build section around the new target. New "Re-baking DB drivers after an existing build" subsection explains when `rebuild-db*.sh` is needed (existing tree) vs. not (fresh tree).

## Out of scope (per #67)

Not touched here, each a separate follow-up:

- `libffi` sed-stripping DWARF CFI directives — works, just surprising.
- `libz` `-include unistd.h` compat hack — same.
- The dead `prebuilt/fetch-libraries.sh` (263 lines, URL commented out since forever) — candidate for deletion later.

## Verified on macOS arm64

Full `make prebuilt-mac` on a clean tree completes in ~10 min, producing all the `.a` files in `prebuilt/lib/mac/`. Follow-up `make compile-mac` → `** BUILD SUCCEEDED **` with signed `HyperXTalk.app`.

## Test plan

- [ ] `brew install openssl@3 libpq mysql-client && make prebuilt-mac` completes end-to-end.
- [ ] Intentionally `brew uninstall mysql-client` → `make prebuilt-mac` fails at the prereq check with a clean error.
- [ ] `make compile-mac` after → `** BUILD SUCCEEDED **`.
- [ ] Spot check: `nm prebuilt/lib/mac/libpq.a | grep -c 'T _PQ'` > 100 (real libpq, not stub).