### PR TITLE
allow specialFolderPath(documents) on linux

### DIFF
--- a/engine/src/dsklnx.cpp
+++ b/engine/src/dsklnx.cpp
@@ -995,6 +995,10 @@ public:
             return MCStringFormat(r_folder, "%@/Desktop", *t_home);
         else if (MCNameIsEqualToCaseless(p_type, MCN_home))
             return MCStringCopy(*t_home, r_folder);
+        else if (MCNameIsEqualToCaseless(p_type, MCN_documents))
+            /* Assume the documents folder is ~/Documents (which is at least true for English localizations). */
+            // TODO: Is there an easy way to localize this?
+            return MCStringFormat(r_folder, "%@/Documents", *t_home);
         else if (MCNameIsEqualToCaseless(p_type, MCN_temporary))
             return MCStringCreateWithCString("/tmp", r_folder);
         // SN-2014-08-08: [[ Bug 13026 ]] Fix ported from 6.7


### PR DESCRIPTION
This patch adds support for the `documents` keyword to the `specialFolderPath` function using the same (simple) implementation approach as the `desktop` keyword, i.e. the users home folder is appended with `/Documents`. Note that this, like the other specialFolderPath() options, will work with English names for the folders. Not clear if there's an easy way to localize these.
