### PR TITLE
import snapshot no longer hangs linux

### DIFF
--- a/engine/src/lnxdcs.cpp
+++ b/engine/src/lnxdcs.cpp
@@ -1059,7 +1059,9 @@ MCImageBitmap *MCScreenDC::snapshot(MCRectangle &r, uint4 window, MCStringRef di
     if (window == 0 && r.x == -32768)
     {
         // Switch to a box drawing cursor and take control of the pointer
-        GdkCursor *t_cursor = gdk_cursor_new(GDK_PLUS);
+		// MDW bugfix_17257
+        // GdkCursor *t_cursor = gdk_cursor_new(GDK_PLUS);
+        GdkCursor *t_cursor = gdk_cursor_new_from_name(dpy, "crosshair");
         if (gdk_pointer_grab(t_root, False,
                              GdkEventMask(GDK_POINTER_MOTION_MASK|GDK_BUTTON_PRESS_MASK|GDK_BUTTON_RELEASE_MASK),
                              NULL, t_cursor, GDK_CURRENT_TIME) != GDK_GRAB_SUCCESS)
@@ -1148,7 +1150,8 @@ MCImageBitmap *MCScreenDC::snapshot(MCRectangle &r, uint4 window, MCStringRef di
                     break;
                     
                 case GDK_BUTTON_PRESS:
-                    x11::gdk_x11_grab_server();
+					// MDW bugfix_17257
+					// x11::gdk_x11_grab_server();
                     MCeventtime = gdk_event_get_time(t_event);
                     t_start_x = t_event_button->x;
                     t_start_y = t_event_button->y;
@@ -1159,12 +1162,14 @@ MCImageBitmap *MCScreenDC::snapshot(MCRectangle &r, uint4 window, MCStringRef di
                     
                 case GDK_BUTTON_RELEASE:
                     MCeventtime = gdk_event_get_time(t_event);
-                    setmods(t_event_button->state, 0, t_event_button->button, True);
+					// MDW bugfix_17257
+                    // setmods(t_event_button->state, 0, t_event_button->button, True);
                     gdk_draw_rectangle(t_root, t_gc, FALSE, t_rect.x, t_rect.y, t_rect.width - 1, t_rect.height - 1);
                     r = MCU_compute_rect(t_start_x, t_start_y, t_event_button->x, t_event_button->y);
                     if (r.width < 4 && r.height < 4)
                         r.width = r.height = 0;
-                    x11::gdk_x11_ungrab_server();
+ 					// MDW bugfix_17257
+                   // x11::gdk_x11_ungrab_server();
                     t_done = true;
                     break;
                     
@@ -1173,7 +1178,7 @@ MCImageBitmap *MCScreenDC::snapshot(MCRectangle &r, uint4 window, MCStringRef di
                     break;
 
 				default:
-					/* Ignore this event */
+					// ignore all other events
 					break;
             }
             


### PR DESCRIPTION
This fixes bugzilla #17257. And bugzilla #15541 and #15103. The 'import snapshot' command would hang linux. And this is not an easy task - required a complete reboot of the system. This patch restores the ability to import snapshots without hanging.