### PR TITLE
fix SSL_get_peer_certificate breaking revsecurity on linux

### DIFF
--- a/engine/src/opensslsocket.cpp
+++ b/engine/src/opensslsocket.cpp
@@ -2396,11 +2396,7 @@ static long post_connection_check(SSL *ssl, char *host)
 	STACK_OF(GENERAL_NAME) *t_alt_names = NULL;
 	int t_idx = -1;
 
-	#if OPENSSL_VERSION_NUMBER >= 0x30000000L
 	if (!(cert = SSL_get1_peer_certificate(ssl)) || !host)
-#else
-	if (!(cert = SSL_get_peer_certificate(ssl)) || !host)
-#endif
 		goto err_occurred;
 
 	while (NULL != (t_alt_names = (STACK_OF(GENERAL_NAME)*)X509_get_ext_d2i(cert, NID_subject_alt_name, NULL, &t_idx)))

--- a/thirdparty/libopenssl/ssl.stubs
+++ b/thirdparty/libopenssl/ssl.stubs
@@ -234,7 +234,6 @@ ssl ./revsecurity ./revsecurity ./revsecurity
 	SSL_set_connect_state: (pointer) -> ()
 	SSL_set_accept_state: (pointer) -> ()
 	SSL_get1_peer_certificate: (pointer) -> (pointer)
-	SSL_get_peer_certificate: (pointer) -> (pointer)
 	SSL_get_verify_result: (pointer) -> (integer)
 	SSL_get_peer_cert_chain: (pointer) -> (pointer)
 	SSL_get_current_cipher: (pointer) -> (pointer)


### PR DESCRIPTION
SSL_get_peer_certificate is a macro in OpenSSL 3.x, not an exported symbol — the weak linker fails to dlsym it and bails, killing the entire ssl module. removes the dead 1.x name from ssl.stubs and the version guard in opensslsocket.cpp, consistent with how the EVP renames were handled in #53.

fixes the `Unable to load: SSL_get_peer_certificate` / `could not load library: ./revsecurity` error @mwieder reported in https://github.com/emily-elizabeth/HyperXTalk/pull/53#issuecomment-4315148983.