### PR TITLE
Implement mouse event handlers in defaultscript

### DIFF
--- a/extensions/widgets/svgpath/support/defaultscript.livecodescript
+++ b/extensions/widgets/svgpath/support/defaultscript.livecodescript
@@ -1,5 +1,19 @@
-﻿script "com.livecode.widget.svgpath.__DefaultScript"
+script "com.livecode.widget.svgpath.__DefaultScript"
 on mouseUp
    -- Toggle the hilited property when clicked
-   set the hilited of me to (not the hilited of me)
+   -- set the hilited of me to (not the hilited of me)
 end mouseUp
+
+on mouseDoubleUp
+end mouseDoubleUp
+
+on mouseDown
+   -- Toggle the hilited property when clicked
+   --  set the hilited of me to (not the hilited of me)
+end mouseDown
+
+on mouseLeave
+end mouseLeave
+
+on mouseEnter
+end mouseEnter


### PR DESCRIPTION
Added mouse event handlers for mouseDoubleUp, mouseDown, mouseLeave, and mouseEnter to default scripts just to make using the SVGPath widget like a button a little bit easier.