### PR TITLE
Update revideextensionlibrary.livecodescript

### DIFF
--- a/ide/Toolset/libraries/revideextensionlibrary.livecodescript
+++ b/ide/Toolset/libraries/revideextensionlibrary.livecodescript
@@ -1,36 +1,31 @@
-﻿script "revideextensionlibrary"
+script "revideextensionlibrary"
+
 local sExtensions, sExtensionProperties, sModuleVersion
 
 constant kExtensionUtils = "com.livecode.library.extension-utils"
 private function __PathToExtensionUtils
-   -- revIDESpecialFolderPath("extensions") is patched in revidelibrary to
-   -- return packaged_extensions in installed mode and the dev Extensions
-   -- folder otherwise, so we can rely on it directly.
-   -- Note: revIDESpecialFolderPath sets itemdelimiter to "/"; reset to "."
-   -- afterwards so that item -1 of kExtensionUtils splits on ".".
-   local tExtDir
-   put revIDESpecialFolderPath("extensions") into tExtDir
    set the itemdelimiter to "."
-   return tExtDir & slash & kExtensionUtils & slash & \
-      item -1 of kExtensionUtils & "." & "livecodescript"
+   return revIDESpecialFolderPath("extensions") & slash & \
+      kExtensionUtils & slash & item -1 of kExtensionUtils & "." & \
+      "livecodescript"
 end __PathToExtensionUtils
 
 on extensionInitialize
-    if the target is not me then
-       pass extensionInitialize
-    end if
-    
-    insert script of me into back
-    
-    # Explicitly load extension utils first
-    revInternal__LoadLibrary "extension-utils", __PathToExtensionUtils()
+   if the target is not me then
+      pass extensionInitialize
+   end if
 
-    if the result is not empty then
-       throw the result
-    end if
+   insert script of me into back
 
-    # Load all the extensions ready for use
-    __extensionsLoad
+   # Explicitly load extension utils first
+   revInternal__LoadLibrary "extension-utils", __PathToExtensionUtils()
+
+   if the result is not empty then
+      throw the result
+   end if
+
+   # Load all the extensions ready for use
+   __extensionsLoad
 end extensionInitialize
 
 on extensionFinalize
@@ -46,11 +41,11 @@ private function __ModuleVersion
    return sModuleVersion
 end __ModuleVersion
 
+--- Get the module filename, could be earlier version of module format. indicate with pUseVersion boolean
 function revIDEExtensionBytecodeFilename pUseVersion
-   if pUseVersion is empty then 
+   if pUseVersion is empty then
       put true into pUseVersion
    end if
-   
    if pUseVersion then
       return "module." & __ModuleVersion() & ".lcm"
    else
@@ -68,12 +63,12 @@ command revIDEExtensionDownloadAndInstall pExtensionPath, pType, pCallbackObject
    local tCacheIndex
    __extensionDownloadBegin pExtensionPath, pType, pCallbackObject, pCallbackMessage
    put it into tCacheIndex
-   
+
    if the result is not empty then
       answer error the result
       exit revIDEExtensionDownloadAndInstall
    end if
-   
+
    # Download the package and install
    __extensionPropertySet tCacheIndex, "package_url", pExtensionPath
    try
@@ -87,12 +82,12 @@ end revIDEExtensionDownloadAndInstall
 private function __extensionDependencyExists pExt
    return __extensionCacheID("name", pExt) is a number
 end __extensionDependencyExists
-   
+
 private command __extensionInstallPackage pPackageLocation
    if there is not a file pPackageLocation then
       throw "No package found at" && pPackageLocation
    end if
-   
+
    local tCacheIndex
    put __extensionCacheID("download_package_path", pPackageLocation) \
          into tCacheIndex
@@ -102,7 +97,7 @@ private command __extensionInstallPackage pPackageLocation
       __extensionUpdateUIWithPackage tCacheIndex, pPackageLocation
    end if
    __extensionPropertySet tCacheIndex, "status", "installing"
-   
+
    local tVerifyResult, tName
    __extensionDownloadVerify tCacheIndex
    put the result into tVerifyResult
@@ -110,9 +105,9 @@ private command __extensionInstallPackage pPackageLocation
       __extensionCacheRemove tCacheIndex
       throw "Error installing extension" && pPackageLocation & return & the result
    end if
-   
+
    put __extensionPropertyGet(tCacheIndex, "name") into tName
-   
+
    # Fetch the dependency list (minus builtin modules) and ensure all
    # are loaded
    local tDeps
@@ -140,7 +135,7 @@ command revIDEExtensionInstall pPackageLocation
 end revIDEExtensionInstall
 
 # Uninstalls the extension
-command revIDEExtensionUninstall pName 
+command revIDEExtensionUninstall pName
    local tCacheIndex, tName
    # Start the uninstall process
    if pName is a number then
@@ -150,7 +145,7 @@ command revIDEExtensionUninstall pName
       put __extensionCacheID("name", pName) into tCacheIndex
       put pName into tName
    end if
-   
+
    # Get the path to the package file
    local tExtensionPackageFile, tInstallPath
    put __extensionPropertyGet(tCacheIndex, "download_package_path") into tExtensionPackageFile
@@ -167,42 +162,66 @@ command revIDEExtensionUninstall pName
    __extensionsChanged
 end revIDEExtensionUninstall
 
-# Returns the extension data
+
+/**
+Summary: Returns the extension data as an array
+
+Parameters:
+pType (optional string): "library","widgets","modules","plugins"
+pStatus (optional string): "installed" to limit results to installed extensions
+pWithoutInvisible (optional boolean): treu to exclude 'userInvisible' extensions
+
+Example:
+// list widget extensions of any install-status:
+put revIDEExtensions ("library",,false] into tArray; put the keys of tArray
+
+// list plugin add-on extensions:
+put revIDEExtensions ("plugin","installed",false) into tArray; put the keys of tArray
+**/
 function revIDEExtensions pType, pStatus, pWithoutInvisible
    # No type passed so return all extensions
-   
+
    # Repeat over the extension array looking for elements with matching type
    local tExtensions, tExtension
    repeat for each key tCacheId in sExtensions
       put sExtensions[tCacheId] into tExtension
-      if tExtension["name"] is empty then 
+      if tExtension["name"] is empty then
          __extensionCacheRemove tCacheId
          next repeat
       end if
-      if pType is not empty and tExtension["type"] is not pType then 
+      if pType is not empty and tExtension["type"] is not pType then
          next repeat
       end if
       if pStatus is not empty then
-         if tExtension["status"] is not pStatus then 
+         if tExtension["status"] is not pStatus then
             next repeat
          end if
       end if
-      
+
       if pWithoutInvisible and not tExtension["uservisible"] then
          next repeat
       end if
-      
+
       put tExtension into tExtensions[tExtension["name"]]
    end repeat
    return tExtensions
 end revIDEExtensions
 
-# Returns the extension data
-function revIDEExtensionProperties pTypeID
-   return sExtensionProperties[pTypeID]
+/**
+Summary: Returns an Array of an extension's properties
+
+Parameters:
+pExtID (string): an Extension name-space identifier string
+
+Example:
+// list extension property names:
+put revIDEExtensionProperties ("com.livecode.library.scriptitems") into tArray; put the keys of tArray
+**/
+function revIDEExtensionProperties pExtID
+   return sExtensionProperties[pExtID]
 end revIDEExtensionProperties
 
-# organise the property info into the structure that the inspectors 
+# organise the property info into the structure that the inspectors
 # expect, namely [<section>]["grouplist"][<group>]["proplist"][<prop>]
 private function __OrganiseInspectorMetadata pDataA
    local tExtensionPropsInfoA
@@ -213,17 +232,29 @@ private function __OrganiseInspectorMetadata pDataA
       put pDataA[tProp]["label"] into tGroup
       put pDataA[tProp]["section"] into tSection
       put tPropInfoA into tExtensionPropsInfoA[tSection]["grouplist"][tGroup]["proplist"][tProp]
-      
+
       put true into tExtensionPropsInfoA[tSection]["grouplist"][tGroup]["widget_prop"]
       put tOrder into tExtensionPropsInfoA[tSection]["grouplist"][tGroup]["order"]
    end repeat
    return tExtensionPropsInfoA
 end __OrganiseInspectorMetadata
 
+
+/**
+Summary: Returns an Array of an extension's properties
+
+Parameters:
+pTypeId (string): an Extension name-space identifier string
+pOrganise (optional boolean): true for the result array to be organized by section
+
+Example:
+// list extension property names for the Clock Widget:
+put revIDEExtensionPropertiesInfo ("com.livecode.widget.clock",false) into tArray; put the keys of tArray
+**/
 function revIDEExtensionPropertiesInfo pTypeId, pOrganise
    local tPropsA, tExtensionPropsInfoA
    put revIDEExtensionProperties(pTypeId) into tPropsA
-   
+
    if pOrganise then
       return __OrganiseInspectorMetadata(tPropsA)
    else
@@ -231,43 +262,94 @@ function revIDEExtensionPropertiesInfo pTypeId, pOrganise
    end if
 end revIDEExtensionPropertiesInfo
 
-function revIDEExtensionProperty pKind, pProperty
+/**
+Summary: Returns a specfic properties of an extension's properties
+
+Parameters:
+pExtID (string): an Extension name-space identifier string
+pProperty (string): the name of the property to reteive
+
+Example:
+// get the extension title:
+put revIDEExtensionProperty("com.livecode.library.scriptitems","title")
+**/
+function revIDEExtensionProperty pExtID, pProperty
    local tExtensionID
-   put __extensionCacheID("name", pKind) into tExtensionID
-   
+   put __extensionCacheID("name", pExtID) into tExtensionID
+
    if pProperty is "api" then
       return __TypeToAPI(__extensionPropertyGet(tExtensionID, "type"))
    end if
-   
+
    return __extensionPropertyGet(tExtensionID, pProperty)
 end revIDEExtensionProperty
 
-command revIDEExtensionToggleUserVisibility pKind
+/**
+Summary: Toggle an extension visibility to the IDE user
+
+Parameters:
+pExtID (string): an Extension name-space identifier string
+
+Example:
+// hide/show the Tree View widget
+revIDEExtensionToggleUserVisibility "com.livecode.widget.treeview"
+**/
+command revIDEExtensionToggleUserVisibility pExtID
    local tCacheId
-   put __extensionCacheID("name", pKind) into tCacheId
-   
+   put __extensionCacheID("name", pExtID) into tCacheId
+
    local tUserVisible
    put __extensionPropertyGet(tCacheId, "uservisible") \
          into tUserVisible
    __extensionPropertySet tCacheId, "uservisible", not tUserVisible
-   revIDESetPreferenceOfSet pKind, "uservisible", not tUserVisible
+   revIDESetPreferenceOfSet pExtID, "uservisible", not tUserVisible
 end revIDEExtensionToggleUserVisibility
 
-command revIDEExtensionToggleLoadOnStartup pKind
+/**
+Summary: Toggle wether or not an extension loads aton IDE startup
+
+Parameters:
+pExtID (string): an Extension name-space identifier string
+
+Example:
+// Turn on/off loading of the Analog Clock widget
+revIDEExtensionToggleLoadOnStartup "com.livecode.widget.clock"
+**/
+command revIDEExtensionToggleLoadOnStartup pExtID
    local tLoadOnStartup
-   put revIDEGetPreferenceOfSet(pKind, "loadOnStartup") into tLoadOnStartup
+   put revIDEGetPreferenceOfSet(pExtID, "loadOnStartup") into tLoadOnStartup
    if tLoadOnStartup is empty then
       put true into tLoadOnStartup
    end if
    revIDEExtensionSetLoadOnStartup pKind, not tLoadOnStartup
 end revIDEExtensionToggleLoadOnStartup
 
-command revIDEExtensionSetLoadOnStartup pKind, pValue
-   revIDESetPreferenceOfSet pKind, "loadOnStartup", pValue
+/**
+Summary: Set wether or not an extension loads on IDE startup
+
+Parameters:
+pExtID (string): an Extension name-space identifier string
+pValue (Boolean): true or false
+
+Example:
+// Turn off loading of the Analog Clock widget
+revIDEExtensionToggleLoadOnStartup "com.livecode.widget.clock", false
+**/
+command revIDEExtensionSetLoadOnStartup pExtID, pValue
+   revIDESetPreferenceOfSet pExtID, "loadOnStartup", pValue
 end revIDEExtensionSetLoadOnStartup
 
-function revIDEExtensionGetLoadOnStartup pKind
-   return revIDEGetPreferenceOfSet(pKind, "loadOnStartup") is not false
+/**
+Summary: get wether or not an extension loads on IDE startup
+
+Parameters:
+pExtID (string): an Extension name-space identifier string
+
+Example:
+put revIDEExtensionGetLoadOnStartup("com.livecode.widget.clock")
+**/
+function revIDEExtensionGetLoadOnStartup pExtID
+   return revIDEGetPreferenceOfSet(pExtID, "loadOnStartup") is not false
 end revIDEExtensionGetLoadOnStartup
 
 function revIDEExtensionStandaloneSettings pID
@@ -278,10 +360,21 @@ function revIDEExtensionStandaloneSettings pID
    return __extensionPropertyGet(tCacheIndex, "standaloneSettings")
 end revIDEExtensionStandaloneSettings
 
+
+/**
+Summary: get the standalone settings for an extension
+
+Parameters:
+pTypeId (string): an Extension name-space identifier string
+pOrganise (optional Boolean): sert to SB ta panel
+
+Example:
+get revIDEExtensionStandaloneSettingsInfo("com.livecode.widget.clock", false); put the keys of it
+**/
 function revIDEExtensionStandaloneSettingsInfo pTypeId, pOrganise
    local tPropsA, tExtensionPropsInfoA
    put revIDEExtensionStandaloneSettings(pTypeId) into tPropsA
-   
+
    if pOrganise then
       return __OrganiseInspectorMetadata(tPropsA)
    else
@@ -299,25 +392,25 @@ private command __extensionDownloadBegin pExtensionUrl, pType, pCallbackObject, 
       return "Could not download extension. The extension must be a URL" && \
             "to a valid package:" && pExtensionUrl for error
    end if
-   
+
    # Get the ID of the extension in the cache
    local tCacheIndex
    put __extensionCacheID("package_url",pExtensionUrl) into tCacheIndex
-   
+
    if tCacheIndex is empty then
       put __extensionCacheID("download_package_path",pExtensionUrl) into tCacheIndex
    end if
-   
+
    # If the extension cache ID couldn't be found, generate a new one
-   if tCacheIndex is empty then 
+   if tCacheIndex is empty then
       put the number of elements of sExtensions + 1 into tCacheIndex
    end if
-   
+
    # Add callback data to cache
    __extensionPropertySet tCacheIndex, "callback_target", pCallbackObject
    __extensionPropertySet tCacheIndex, "callback_handler", pCallbackMessage
    __extensionPropertySet tCacheIndex, "name", "New Extension"
-   
+
    # AL-2015-03-06: [[ Bug 14820 ]] Set the type so that the icon is correct while downloading
    __extensionPropertySet tCacheIndex, "type", pType
    return tCacheIndex for value
@@ -333,7 +426,7 @@ private command __extensionUpdateUIWithPackage pCacheIndex, pPath
       delete the last item of tName
    end repeat
    __extensionPropertySet pCacheIndex, "name", tName
-   
+
    # Send update to refresh UI with new package installation
    doExtensionsChanged
 end __extensionUpdateUIWithPackage
@@ -343,29 +436,29 @@ private command __extensionDownload pCacheIndex
    # Check the file extension is correct
    local tURL
    put __extensionPropertyGet(pCacheIndex,"package_url") into tURL
-   
+
    set the itemdel to "."
-   if the last item of tURL is not "lce" then 
+   if the last item of tURL is not "lce" then
       return __extensionError(pCacheIndex, \
             "The package must have the file extension 'lce':" && tURL)
    end if
-   
+
    local tPackageFilePath
    set the itemdel to "/"
    put the last item of tURL into tPackageFilePath
-   
+
    __extensionPropertySet pCacheIndex, "download_package_path", revIDESpecialFolderPath("downloading extensions") & slash & tPackageFilePath
    __extensionPropertySet pCacheIndex, "status", "downloading"
    __extensionPropertySet pCacheIndex, "progress_message", "Downloading"
    __extensionPropertySet pCacheIndex, "progress", 0
    __extensionPropertySet pCacheIndex, "label", tPackageFilePath
    __extensionPropertySet pCacheIndex, "downloaded_from_store", true
-   
+
    __extensionUpdateUIWithPackage pCacheIndex, tPackageFilePath
-   
+
    # Update progress
    __extensionSendProgressUpdate pCacheIndex, "Downloading", 0
-   
+
    # Download the extension to a file
    libURLDownloadToFile tURL, __extensionPropertyGet(pCacheIndex,"download_package_path"), "extensionDownloaded"
 end __extensionDownload
@@ -378,12 +471,12 @@ end extensionDownloaded
 private command __extensionDownloaded pURL, pDownloadStatus
    # Get the index of the extension
    local tCacheIndex
-   
+
    put __extensionCacheID("package_url", pURL) into tCacheIndex
-   
+
    # Update progress
    __extensionSendProgressUpdate tCacheIndex, "Download Complete", 100
-   
+
    local tPath
    put __extensionPropertyGet(tCacheIndex,"download_package_path") into tPath
    revIDEExtensionInstall tPath
@@ -393,36 +486,36 @@ end __extensionDownloaded
 private command __extensionDownloadVerify pCacheIndex
    # Update progress
    __extensionSendProgressUpdate pCacheIndex, "Verifying extension", 0
-   
+
    # Get the path to the extension
    local tExtensionPath
    put __extensionPropertyGet(pCacheIndex, "download_package_path") into tExtensionPath
-   
+
    # Check the package exists
-   if there is not a file tExtensionPath then 
+   if there is not a file tExtensionPath then
       return __extensionError(pCacheIndex, \
             "Package does not exist: " && tExtensionPath)
    end if
-   
+
    # Check the file extension is valid
    set the itemdel to "."
-   if the last item of tExtensionPath is not "lce" then 
+   if the last item of tExtensionPath is not "lce" then
       return __extensionError(pCacheIndex, "The package extension '" & \
             the last item of tExtensionPath&"' is not valid." && \
             " Must be 'lce'.")
    end if
-   
+
    # Ensure the zip contains the things we expect
    local tManifestDataA
    extensionValidateLCEPackage tExtensionPath, tManifestDataA
    if the result is not empty then
       return the result
    end if
-   
+
    repeat for each key tKey in tManifestDataA
       __extensionPropertySet pCacheIndex, tKey, tManifestDataA[tKey]
    end repeat
-   
+
    # Build the type ID from the name and version
    __extensionPropertySet pCacheIndex, "type_id", \
          tManifestDataA["name"] & "." & tManifestDataA["version"]
@@ -434,7 +527,7 @@ private command __extensionInstall pCacheIndex, pPackage
    put __extensionPropertyGet(pCacheIndex, "type_id") into tTypeId
    put revIDESpecialFolderPath("user extensions") & slash & tTypeId into tInstallPath
    revIDEEnsurePath tInstallPath
-   
+
    __extensionInstallRemoveOlderVersions pCacheIndex, tName, 15
    __extensionInstallExtract pCacheIndex, tInstallPath, tTypeID, pPackage, 30
    __extensionInstallCopyInterfaceFile pCacheIndex, tName, tInstallPath, 50
@@ -444,7 +537,7 @@ end __extensionInstall
 
 on __extensionInstallRemoveOlderVersions pCacheIndex, pName, pProgress
    __extensionSendProgressUpdate pCacheIndex, "Removing older versions", pProgress
-   
+
    repeat for each key tCacheIndex in sExtensions
       if tCacheIndex is pCacheIndex then next repeat
       if sExtensions[tCacheIndex]["name"] is pName then
@@ -456,7 +549,7 @@ end __extensionInstallRemoveOlderVersions
 private command __extensionPackageExtract pPackage, pTargetFolder
    # Extract the icon,docs and executable module into the folder
    revZipOpenArchive pPackage, "read"
-   
+
    # Work out the root of the zip
    local tZipItems, tZipRoot
    put revZipEnumerateItems(pPackage) into tZipItems
@@ -465,7 +558,7 @@ private command __extensionPackageExtract pPackage, pTargetFolder
    else
       put empty into tZipRoot
    end if
-   
+
    # Extract all the files
    local tDirectory
    set the itemdel to slash
@@ -473,8 +566,8 @@ private command __extensionPackageExtract pPackage, pTargetFolder
       put pTargetFolder & slash & item 1 to -2 of tFile into tDirectory
       revIDEEnsurePath(tDirectory)
       revZipExtractItemToFile pPackage, tFile, pTargetFolder & slash & tFile
-   end repeat 
-   
+   end repeat
+
    revZipCloseArchive pPackage
 end __extensionPackageExtract
 
@@ -482,9 +575,9 @@ end __extensionPackageExtract
 private command __extensionInstallExtract pCacheIndex, pFinalPath, pTypeId, pPackage, pProgress
    # Update progress
    __extensionSendProgressUpdate pCacheIndex, "Extracting extension", pProgress
-   
-   __extensionPropertySet pCacheIndex, "install_path", pFinalPath 
-   
+
+   __extensionPropertySet pCacheIndex, "install_path", pFinalPath
+
    # Extract into final directory
    __extensionPackageExtract pPackage, pFinalPath
 end __extensionInstallExtract
@@ -492,12 +585,12 @@ end __extensionInstallExtract
 private command __extensionInstallCopyInterfaceFile pCacheIndex, pName, pInstallFolder, pProgress
    # Update progress
    __extensionSendProgressUpdate pCacheIndex, "Copying interface file", pProgress
-   
+
    # AL-2015-03-15: [[ Bug 15008 ]] Move interface file to interface folder
    local tInterfaceFile, tInterfacePath
    put pName & ".lci" into tInterfaceFile
    put pInstallFolder & slash & tInterfaceFile into tInterfacePath
-   
+
    if there is a file tInterfacePath then
       local tTargetFolder
       put revIDESpecialFolderPath("user extensions") & slash & \
@@ -513,13 +606,13 @@ private command __extensionInstallLoad pCacheIndex, pName, pInstallFolder, pProg
    if tFolderData is empty then
       throw "extension missing from" && pInstallFolder
    end if
-   
+
    local tDataA
    put tFolderData[pName][pInstallFolder] into tDataA["copies"][1]
-   
+
    -- add any previously cached info
    union tDataA["copies"][1] with sExtensions[pCacheIndex] recursively
-   
+
    local tExisting
    repeat for each key tExtensionID in sExtensions
       if tExtensionID is pCacheIndex then next repeat
@@ -527,11 +620,11 @@ private command __extensionInstallLoad pCacheIndex, pName, pInstallFolder, pProg
          put sExtensions[tExtensionID]["copies"] into tExisting
       end if
    end repeat
-   
+
    repeat for each key tKey in tExisting
       put tExisting[tKey] into tDataA["copies"][tKey + 1]
    end repeat
-   
+
    __extensionLoad pName, tDataA
 end __extensionInstallLoad
 
@@ -548,11 +641,11 @@ on __extensionInstallFinalise pCacheIndex, pTypeId
          revDeleteFile tTempInstallPackage
       end if
    end if
-   
+
    # Update the cache
    __extensionSendProgressUpdate  pCacheIndex, "Complete", 100
    __extensionPropertySet pCacheIndex, "status", "installed"
-   
+
    # Notify palettes
    __extensionsChanged
 end __extensionInstallFinalise
@@ -565,7 +658,7 @@ end __extensionInstallFinalise
 private command __extensionUninstallCheckInUse pCacheIndex, pProgress
    # Update progress
    if pCacheIndex is not a number then return __extensionError(pCacheIndex, "Could not remove extension '" & pCacheIndex & "' because it is not a valid index")
-   
+
    __extensionSendProgressUpdate pCacheIndex, "Checking if extension is in use", pProgress
 end __extensionUninstallCheckInUse
 
@@ -573,7 +666,7 @@ end __extensionUninstallCheckInUse
 private command __extensionUninstallUnload pCacheIndex, pName, pProgress
    # Update progress
    __extensionSendProgressUpdate pCacheIndex, "Unloading extension", pProgress
-   
+
    revIDEExtensionUnload pName
 end __extensionUninstallUnload
 
@@ -581,12 +674,12 @@ end __extensionUninstallUnload
 private command __extensionUninstallDeleteFiles pCacheIndex, pName, pInstallPath, pProgress
    # Update progress
    __extensionSendProgressUpdate pCacheIndex, "Deleting extension files", pProgress
-   
+
    # Make sure the path contains the folder extension as a check before deleting a folder
    if pInstallPath begins with revIDESpecialFolderPath("user extensions") then
       revDeleteFolder pInstallPath
    end if
-   
+
    # AL-2015-03-15: [[ Bug 15008 ]] Delete interface file from interface folder
    local tInterfaceFile
    put pName & ".lci" into tInterfaceFile
@@ -598,14 +691,14 @@ end __extensionUninstallDeleteFiles
 private command __extensionUninstallDeletePreferences pCacheIndex, pName, pProgress
    # Update progress
    __extensionSendProgressUpdate pCacheIndex, "Deleting preferences", pProgress
-   
+
    revIDEDeletePreferenceSet pName
 end __extensionUninstallDeletePreferences
 
 private command __extensionUnload pCacheIndex, pName, pProgress
    # Update progress
    __extensionSendProgressUpdate pCacheIndex, "Unloading extension", pProgress
-   
+
    revIDEExtensionUnload pName
 end __extensionUnload
 
@@ -624,22 +717,22 @@ private command __ProcessInspectorMetadata @xMetadataA
       if xMetadataA[tKey]["section"] is empty then
          put "Basic" into xMetadataA[tKey]["section"]
       end if
-      
+
       if xMetadataA[tKey]["label"] is empty then
          put tKey into xMetadataA[tKey]["label"]
       end if
-      
+
       # Process value options, default and delimiter
       replace comma with return in xMetadataA[tKey]["options"]
       replace "\n" with return in xMetadataA[tKey]["delimiter"]
       if xMetadataA[tKey]["default"] is not empty then
          replace "\n" with return in xMetadataA[tKey]["default"]
       end if
-      
+
       if xMetadataA[tKey]["user_visible"] is empty then
          put true into xMetadataA[tKey]["user_visible"]
       end if
-      
+
       if xMetadataA[tKey]["properties"] is not empty then
          -- If there is a 'properties' value, delete the key
          -- and replace it with that value
@@ -658,14 +751,14 @@ private function __extensionPropertyInfoFromManifest pId, pManifestPath
    # Create the XML tree
    local tXMLTree, tProperties, tExtensionData, tPropertyNodes
    put revXMLCreateTreeFromFile(pManifestPath,true,true,false) into tXMLTree
-   
+
    put revXMLChildNames(tXMLTree,"package",return,"property",true) into tPropertyNodes
-   
+
    local tCacheID
    put __extensionCacheID("name", pID) into tCacheId
-   
+
    local tPropertyNames, tPropertyXMLData, tPropNameList, tMaxOrder
-   repeat for each line tPropertyNode in tPropertyNodes      
+   repeat for each line tPropertyNode in tPropertyNodes
       local tName
       put revXMLAttribute(tXMLTree,"package" & "/" & tPropertyNode,"name") into tName
       put __extensionPropertyGet(tCacheId, tName) into tPropertyXMLData[tName]["data"]
@@ -676,19 +769,19 @@ private function __extensionPropertyInfoFromManifest pId, pManifestPath
       put tName into tPropNameList[tPropertyNode]
       put max(tMaxOrder, tPropertyXMLData[tName]["data"]["order"]) into tMaxOrder
    end repeat
-   
+
    -- Sort by ordered props, then by order of appearance
    repeat for each line tPropertyNode in tPropertyNodes
       if tPropertyXMLData[tPropNameList[tPropertyNode]]["data"]["order"] \
             is empty then
-         add 1 to tMaxOrder 
+         add 1 to tMaxOrder
          put tMaxOrder into tPropertyXMLData[tPropNameList[tPropertyNode]]["data"]["order"]
       end if
    end repeat
-   
+
    put the keys of tPropertyXMLData into tPropertyNames
    sort tPropertyNames by tPropertyXMLData[each]["data"]["order"]
-   
+
    local tPropertyDataA
    repeat for each line tProperty in tPropertyNames
       local tIDEPropertyInfo, tPropertyInfoA
@@ -700,7 +793,7 @@ private function __extensionPropertyInfoFromManifest pId, pManifestPath
       else
          put tPropertyInfoA into tPropertyDataA[tProperty]
       end if
-      
+
       local tReadOnly, tSetter
       put tPropertyXMLData[tProperty]["set"] into tSetter
       if tSetter is empty or tSetter begins with "xmlerr" then
@@ -709,7 +802,7 @@ private function __extensionPropertyInfoFromManifest pId, pManifestPath
          put false into tReadOnly
       end if
       put tReadOnly into tPropertyDataA[tProperty]["read_only"]
-      
+
       if tPropertyDataA[tProperty]["editor"] is empty then
          local tType
          put tPropertyXMLData[tProperty]["get"] into tType
@@ -719,11 +812,11 @@ private function __extensionPropertyInfoFromManifest pId, pManifestPath
             put "com.livecode.pi." & tolower(tType) into tPropertyDataA[tProperty]["editor"]
          end if
       end if
-      # Tag the property as a widget property, so we can order them 
+      # Tag the property as a widget property, so we can order them
       # correctly after the built-in props for the given section
       put true into tPropertyDataA[tProperty]["widget_prop"]
    end repeat
-   
+
    # Fetch property override metadata
    local tMetadataValue, tMetadataKey
    local tMetadataNodes, tMetadataA, tDataA
@@ -736,7 +829,7 @@ private function __extensionPropertyInfoFromManifest pId, pManifestPath
       end if
       __SetMetadata tMetadataKey, tMetadataValue, tDataA
    end repeat
-   
+
    repeat for each key tProperty in tDataA
       if tPropertyXMLData[tProperty] is not empty then
          next repeat
@@ -748,55 +841,55 @@ private function __extensionPropertyInfoFromManifest pId, pManifestPath
          # tData might be non-empty for the property even though
          # there was no property node in the XML
          union tPropertyDataA[tProperty] with tDataA[tProperty]
-         
+
          # Now take any default property info that was not specified
          # in the manifest
          union tPropertyDataA[tProperty] with tIDEPropInfoA
       end if
    end repeat
-   
+
    __ProcessInspectorMetadata tPropertyDataA
-   
+
    revXMLDeleteTree tXMLTree
    return tPropertyDataA
 end __extensionPropertyInfoFromManifest
 
 command revIDEExtensionSetInfo pTypeID
    set the itemdelimiter to slash
-   
+
    # Get the internal cache ID
    local tCacheIndex
    put __extensionCacheID("name", pTypeID) into tCacheIndex
-   
+
    # Get the target folder
    local tFolder
    put __extensionPropertyGet(tCacheIndex, "install_path") into tFolder
-   
+
    # Get information from the download package path if the manifest was not found
    if tFolder is empty then
       put item 1 to -2 of __extensionPropertyGet(tCacheIndex, "download_package_path") into tFolder
    end if
-   
+
    local tManifest
    put tFolder & slash & "manifest.xml" into tManifest
-   if there is not a file tManifest then 
+   if there is not a file tManifest then
       exit revIDEExtensionSetInfo
    end if
-   
+
    __extensionSetExtensionInfoFromManifest tCacheIndex, tManifest
    __extensionSetPropertyInfoFromManifest pTypeID, tManifest
-   
+
    # Set the default name
    local tTitle
    put __extensionPropertyGet(tCacheIndex, "title") into tTitle
    put tTitle into sExtensionProperties[pTypeID]["name"]["default"]
-   
+
 end revIDEExtensionSetInfo
 
 private command __extensionSetExtensionInfoFromManifest pCacheIndex, pManifestPath
    local tDataA
    revIDEExtensionFetchMetadata pManifestPath, tDataA
-   
+
    repeat for each key tKey in tDataA
       __extensionPropertySet pCacheIndex, tKey, tDataA[tKey]
    end repeat
@@ -813,7 +906,16 @@ private function __extensionError pCacheIndex, pErrorMessage
    return pErrorMessage
 end __extensionError
 
-# Send notication that widget has been added/removed
+
+/**
+Send notication that widget has been added/removed.
+
+Description:
+Sends update notification with ideMessageSend "ideExtensionsChanged" to all
+objects that have subscribed to tha IDE message ideExtensionsChanged using <revIDESubscribe>.
+
+References: ideSubscribe (command), ideMessageSend (command)
+**/
 on doExtensionsChanged
    ideMessageSend "ideExtensionsChanged"
 end doExtensionsChanged
@@ -825,6 +927,20 @@ private command __extensionsChanged
    end if
    send "doExtensionsChanged" to me in 10 millisecs
    put the result into sExtensionsChangedMsg
+--
+   get the cDarkMode of stack "revPreferences"
+   if it is true then
+      try
+         setAllToDarkMode
+      end try
+      send "IDEToDarkMode" to me in 0 millisecs
+   else
+      try
+         setAllToLightMode
+      end try
+      send "IDEToLightMode" to me in 0 millisecs
+   end if
+
 end __extensionsChanged
 
 # Sent progress update on installation of widget
@@ -832,7 +948,7 @@ on __extensionSendProgressUpdate pCacheIndex, pMessage, pProgress
    # Get progress information for extension
    __extensionPropertySet pCacheIndex, "progress_message", pMessage
    __extensionPropertySet pCacheIndex, "progress", pProgress
-   
+
    local tName
    put __extensionPropertyGet(pCacheIndex, "name") into tName
    ideMessageSend "ideExtensionStatusChanged", (tName & comma & pMessage & comma & pProgress)
@@ -873,12 +989,12 @@ function revIDEExtensionsOrderByDependency pExtensions
       __extensionAddDependenciesToRequiresArray \
             tExtension, tRequiresA, tExtensions
    end repeat
-   
+
    return extensionOrderByDependency(the keys of tExtensions, tRequiresA)
 end revIDEExtensionsOrderByDependency
 
 private function isUserExtension pData
-   if pData["ide"] then 
+   if pData["ide"] then
       return 1
    end if
    return 0
@@ -889,7 +1005,7 @@ private command addToList pElement, @xArray
 end addToList
 
 on __extensionsLoad
-   local tDataA   
+   local tDataA
    # Fetch all the available data about extensions in the search paths
    local tFoldersA, tExtensionFolder
    put revIDEExtensionFolders() into tFoldersA
@@ -903,12 +1019,12 @@ on __extensionsLoad
          extensionFindInFolder tExtFolder, tKey is "user", true, tDataA
       end repeat
    end repeat
-   
+
    # Now loop through, checking the status of them
    local tExtensionsList, tExtensionsA, tExtensionCount, tExtensionCopyCount, tExtensionDataA
    put the keys of tDataA into tExtensionsList
    sort tExtensionsList
-   
+
    local tToLoadA, tDependentsA, tRequiresA
    set the itemdel to ","
    put 1 into tExtensionCount
@@ -926,18 +1042,18 @@ on __extensionsLoad
          add 1 to tExtensionCopyCount
       end repeat
       put tExtensionDataA into tToLoadA[tTypeID]
-      
+
       put tExtensionDataA["copies"][1]["requires"] into tDependentsA
       repeat for each element tElement in tDependentsA
          addToList tElement, tRequiresA[tTypeId]
       end repeat
       put empty into tExtensionDataA
    end repeat
-   
+
    local tLoadOrder
    put extensionOrderByDependency(tExtensionsList, tRequiresA) into \
-          tLoadOrder
-    
+         tLoadOrder
+
    repeat for each line tLine in tLoadOrder
       # Extension utils is explicitly loaded
       if tLine is kExtensionUtils then
@@ -979,7 +1095,7 @@ private command __extensionLoad pID, pExtensionDataA
    local tLoadedDataA, tToLoadA
    # Only try to load the first copy in the load order
    put pExtensionDataA["copies"][1] into tToLoadA
-   
+
    local tFolder, tVersion, tStatus, tError, tIDEExtension, tSourceFile, tSourceType
    put tToLoadA["install_path"] into tFolder
    put tToLoadA["version"] into tVersion
@@ -1002,11 +1118,11 @@ private command __MapCodeLibraryForIDE pFolder
       local tExtension
       set the itemDelimiter to slash
       put item -2 of pFolder into tExtension
-      
+
       put files(specialFolderPath("engine") & "/" & tExtension) & return & \
             folders(specialFolderPath("engine") & "/" & tExtension) into tLibraries
       filter tLibraries without ".*"
-      
+
       if tLibraries is not empty then
          set the itemDelimiter to "."
          repeat for each line tLibrary in tLibraries
@@ -1019,9 +1135,9 @@ private command __MapCodeLibraryForIDE pFolder
          end repeat
       end if
    end if
-   
+
    -- code folders should be platform ID triples however for the
-   -- time being as we have no way to access the data required to 
+   -- time being as we have no way to access the data required to
    -- determine the options section of the platform ID so we filter only
    -- arch and platform and hope for the best. Ideally we would have
    -- access to a build options string and give a complete match precedence.
@@ -1038,7 +1154,7 @@ private command __MapCodeLibraryForIDE pFolder
          filter tCodeFolders with "*-"& toLower(the platform) & "*"
          break
    end switch
-   
+
    local tFilteredCodeFolders
    filter tCodeFolders with the processor & "-*" into tFilteredCodeFolders
    split tFilteredCodeFolders by return as set
@@ -1051,12 +1167,12 @@ private command __MapCodeLibraryForIDE pFolder
       split tUniveralFilteredCodeFolders by return as set
       union tFilteredCodeFolders with tUniveralFilteredCodeFolders
    end if
-   
+
    repeat for each key tFolder in tFilteredCodeFolders
       put files(pFolder & "/" & tFolder) & return & \
             folders(pFolder & "/" & tFolder) into tLibraries
       filter tLibraries without ".*"
-      
+
       if tLibraries is not empty then
          set the itemDelimiter to "."
          repeat for each line tLibrary in tLibraries
@@ -1073,7 +1189,6 @@ end __MapCodeLibraryForIDE
 private command __LoadExtension pCacheIndex, pExtensionType, pSourceType, \
       pSourceFile, pFolder, pStatus, @xError
    revInternal__Log "Message", the params
-   write "DEBUG __LoadExtension: type=" & pExtensionType & " source=" & pSourceType & " folder=" & pFolder & return to stderr
    if xError is empty then
       local tFileToLoad
       if not __extensionNeedsLoad(pExtensionType) then
@@ -1124,13 +1239,13 @@ private command __revIDELCBExtensionLoad pID, pFolder, pVersion, pStatus, \
    # Find entry in the cache if it exists
    local tCacheIndex
    put __extensionCacheID("install_path", pFolder) into tCacheIndex
-   
+
    # If no entry is in the cache, create one
    if tCacheIndex is not a number then
       put the number of elements of sExtensions + 1 into tCacheIndex
       __extensionPropertySet tCacheIndex, "install_path", pFolder
    end if
-   
+
    local tSupportFiles
    put pAdditionalInfoA["support_files"] into tSupportFiles
    local tLoadOnStartup
@@ -1155,31 +1270,29 @@ private command __revIDELCBExtensionLoad pID, pFolder, pVersion, pStatus, \
          end if
       end if
    else
-      __extensionPropertySet tCacheIndex, "status", "unloaded" 
+      __extensionPropertySet tCacheIndex, "status", "unloaded"
    end if
-   
+
    # Update name, status, error, and whether the extension comes with the IDE
    __extensionPropertySet tCacheIndex, "name", pID
-   __extensionPropertySet tCacheIndex, "type_id", pID  & "." & pVersion 
+   __extensionPropertySet tCacheIndex, "type_id", pID  & "." & pVersion
    __extensionPropertySet tCacheIndex, "ide", pIsIDEExtension
    __extensionPropertySet tCacheIndex, "source_file", pSourceFile
    __extensionPropertySet tCacheIndex, "source_type", "lcb"
    __extensionPropertySet tCacheIndex, "support_files", tSupportFiles
-   
+
    # Check for sample stacks
    __extensionPropertySet tCacheIndex, "samples", __extensionSampleStacks(pID,pFolder)
-   
-    # Store the extension's metadata
-    revIDEExtensionSetInfo pID
-    
-    local tUserVisiblePref
-    put revIDEGetPreferenceOfSet(pID, "uservisible") into tUserVisiblePref
-    if tUserVisiblePref is not empty then
-       __extensionPropertySet tCacheIndex, "uservisible", tUserVisiblePref
-    else
-       __extensionPropertySet tCacheIndex, "uservisible", true
-    end if
-   
+
+   # Store the extension's metadata
+   revIDEExtensionSetInfo pID
+
+   local tUserVisiblePref
+   put revIDEGetPreferenceOfSet(pID, "uservisible") into tUserVisiblePref
+   if tUserVisiblePref is not empty then
+      __extensionPropertySet tCacheIndex, "uservisible", tUserVisiblePref
+   end if
+
    # Deal with the various icon possibilities
    if sExtensionProperties[pID]["svgicon"] is empty then
       local tIconPath
@@ -1188,18 +1301,18 @@ private command __revIDELCBExtensionLoad pID, pFolder, pVersion, pStatus, \
          __extensionPropertySet tCacheIndex, "icon", tIconPath
       end if
    end if
-   
+
    # Load the default script if there is one
    local tDefaultScript
    put revIDEExtensionFetchDefaultScript(pFolder, pID, true) into tDefaultScript
    __extensionPropertySet tCacheIndex, "defaultScript", tDefaultScript
-   
+
    # Generate extension API from source if there is not one present in the folder
    # Don't do in an installed IDE as we might not be able to generate the files in the appropriate location
    if not revEnvironmentIsInstalled() and not there is a file (pFolder & slash & "api.lcdoc") then
       revIDEExtensionUpdateAPI pFolder, pSourceFile
    end if
-   
+
    return pError
 end __revIDELCBExtensionLoad
 
@@ -1224,7 +1337,8 @@ end __UseTypeToKey
 private function __extensionHasID pType
    switch pType
       case "snippet"
-         return false
+         return true
+         -- return false
       default
          return true
    end switch
@@ -1234,32 +1348,32 @@ private function __extensionNeedsLoad pType
    switch pType
       case "snippet"
       case "sample"
+         -- return true
          return false
       default
          return true
    end switch
 end __extensionNeedsLoad
 
-private command __revIDELCSExtensionLoad pFullPath, pFolder, pVersion, pStatus, \
-      pError, pIsIDEExtension, pSourceFile, pAdditionalInfoA, pIsStartup
-   
+private command __revIDELCSExtensionLoad pFullPath, pFolder, pVersion, pStatus, pError, pIsIDEExtension, pSourceFile, pAdditionalInfoA, pIsStartup
+
    # Find entry in the cache if it exists
    local tCacheIndex
    put __extensionCacheID("install_path", pFolder) into tCacheIndex
-   
+
    # If no entry is in the cache, create one
    if tCacheIndex is not a number then
       put the number of elements of sExtensions + 1 into tCacheIndex
       __extensionPropertySet tCacheIndex, "install_path", pFolder
    end if
-   
+
    if pAdditionalInfoA is empty then
       put __fetchExtensionManifestData(pFolder, pSourceFile) into pAdditionalInfoA
    end if
-   
+
    local tType
    put pAdditionalInfoA["type"] into tType
-   
+
    # Update name, status, error, and whether the extension comes with the IDE
    local tId
    if __extensionHasID(tType) then
@@ -1271,45 +1385,47 @@ private command __revIDELCSExtensionLoad pFullPath, pFolder, pVersion, pStatus, 
       # The manifest should contain an id
       put pAdditionalInfoA["name"] into tId
    end if
-   
+
    local tLoadOnStartup
    if pError is empty and __extensionNeedsLoad(tType) then
       put revIDEExtensionGetLoadOnStartup(tID) into tLoadOnStartup
    end if
-   if not pIsStartup or (tLoadOnStartup is not false) then   
+   if not pIsStartup or (tLoadOnStartup is not false) then
       __LoadExtension tCacheIndex, tType, "lcs", pSourceFile, pFolder, pStatus, pError
    else
-      __extensionPropertySet tCacheIndex, "status", "unloaded" 
+      __extensionPropertySet tCacheIndex, "status", "unloaded"
    end if
-   
+
    __extensionPropertySet tCacheIndex, "name", tId
-   __extensionPropertySet tCacheIndex, "type_id", tId  & "." & pVersion 
-   
+   __extensionPropertySet tCacheIndex, "type_id", tId  & "." & pVersion
+
    __extensionPropertySet tCacheIndex, "author", pAdditionalInfoA["author"]
    __extensionPropertySet tCacheIndex, "title", pAdditionalInfoA["title"]
    __extensionPropertySet tCacheIndex, "svgicon", pAdditionalInfoA["svgicon"]
    __extensionPropertySet tCacheIndex, "version", pAdditionalInfoA["version"]
-   
+
    repeat for each key tKey in pAdditionalInfoA["uses"]
       local tSettingString
       put empty into tSettingString
-      -- store info about settings (android permissions etc)            
+      -- store info about settings (android permissions etc)
       repeat for each element tSetting in pAdditionalInfoA["uses"][tKey]
          addToStringList tSettingString, tSetting, ","
       end repeat
       __extensionPropertySet tCacheIndex, __UseTypeToKey(tKey), tSettingString
    end repeat
-   
+
    __extensionPropertySet tCacheIndex, "source_file", pSourceFile
    __extensionPropertySet tCacheIndex, "ide", pIsIDEExtension
    __extensionPropertySet tCacheIndex, "source_type", "lcs"
    __extensionPropertySet tCacheIndex, "type", pAdditionalInfoA["type"]
    __extensionPropertySet tCacheIndex, "uservisible", true
-   __extensionPropertySet tCacheIndex, "support_files", pAdditionalInfoA["support_files"]
-   
+   __extensionPropertySet tCacheIndex, "support_files", pAdditionalInfoA["support_files"] -- tSupportFiles --
+
+   __extensionPropertySet tCacheIndex, "samples", __extensionSampleStacks(tId,pFolder)
+
    # Store the extension's property metadata
-   --  revIDEExtensionSetInfo pID
-   
+    -- revIDEExtensionSetInfo tID
+
    # Deal with the various icon possibilities
    if sExtensionProperties[tID]["svgicon"] is empty then
       local tIconPath
@@ -1318,7 +1434,7 @@ private command __revIDELCSExtensionLoad pFullPath, pFolder, pVersion, pStatus, 
          __extensionPropertySet tCacheIndex, "icon", tIconPath
       end if
    end if
-   
+
    # If this is not startup, then auto-launch snippet or sample stack
    if not pIsStartup then
       if tType is "snippet" then
@@ -1330,6 +1446,9 @@ private command __revIDELCSExtensionLoad pFullPath, pFolder, pVersion, pStatus, 
    return pError
 end __revIDELCSExtensionLoad
 
+
+/**
+**/
 command revIDEExtensionReload pTypeId
    local tCacheIndex
    put __extensionCacheID("name", pTypeID) into tCacheIndex
@@ -1343,10 +1462,12 @@ command revIDEExtensionReload pTypeId
          tDataA["source_file"], tDataA["install_path"], \
          "", tError
    if tError is not empty then
-      answer error tError 
+      answer error tError
    end if
 end revIDEExtensionReload
 
+/**
+**/
 command revIDEExtensionLoad pType, pID, pFolder, pVersion, pStatus, pError, \
       pIDEExtension, pSourceFile, pAdditionalInfoA, pIsStartup
    if pType is "lcb" then
@@ -1362,21 +1483,21 @@ function revIDEExtensionFetchDefaultScript pFolder, pCacheIndex, pValidate
    if there is a stack (pCacheIndex& ".__DefaultScript") then
       return the script of stack (pCacheIndex& ".__DefaultScript")
    end if
-   
+
    local tDefaultScriptPath
    put pFolder & "/support/defaultscript.livecodescript" into tDefaultScriptPath
-   
+
    if there is not a file tDefaultScriptPath then
       return empty
    end if
-   
+
    lock messages
    try
       open stack tDefaultScriptPath
    catch tStackError
       return empty
    end try
-   
+
    local tScript
    if tStackError is empty then
       if pValidate then
@@ -1389,23 +1510,24 @@ function revIDEExtensionFetchDefaultScript pFolder, pCacheIndex, pValidate
       delete stack tDefaultScriptPath
    end if
    unlock messages
-   
+
    return tScript
 end revIDEExtensionFetchDefaultScript
 
 function __extensionSampleStacks pID, pFolder
    local tSampleFolder, tSamples, tSampleArray
-   
+
    # Get the paths to sample satcks in the bundle
-   put pFolder & slash & "samples" into tSampleFolder
+   put pFolder & "/samples" into tSampleFolder
    if there is a folder tSampleFolder then
       put files(tSampleFolder) into tSamples
       filter tSamples without ".*"
       repeat for each line tStack in tSamples
-         put pFolder & slash & "samples/" & tStack into tSampleArray[tStack] 
+         -- put pFolder & slash & "samples/" & tStack & cr after msg -- display sample stacks list in msg box
+          put pFolder & "/samples/" & tStack into tSampleArray[tStack]
       end repeat
    end if
-   
+
    return tSampleArray
 end __extensionSampleStacks
 
@@ -1421,19 +1543,20 @@ end extensionUpdateDataReceived
 private function __TypeToAPI pType
    switch pType
       case "module"
-         return "livecode_builder"
+         return "builder"
          break
       case "plugin"
-         return "livecode_ide"
+         return "ide"
          break
       case "library"
       case "widget"
       default
-         return "livecode_script"
+         return "script"
          break
    end switch
 end __TypeToAPI
 
+-- get revIDEExtensionDocsData("Script"); put the keys of it
 function revIDEExtensionDocsData pForAPI
    local tExtensionsA
    put revIDEExtensions("", "installed", true) into tExtensionsA
@@ -1447,7 +1570,7 @@ function revIDEExtensionDocsData pForAPI
       put tExtension["install_path"] into tDataA[tCount]["folder"]
       put tExtension["title"] into tDataA[tCount]["title"]
       put tExtension["author"] into tDataA[tCount]["author"]
-      put tExtension["source_file"] into tDataA[tCount]["source_file"]      
+      put tExtension["source_file"] into tDataA[tCount]["source_file"]
       put tExtension["source_type"] into tDataA[tCount]["source_type"]
       put tExtension["name"] into tDataA[tCount]["name"]
    end repeat
@@ -1462,14 +1585,14 @@ on revIDEExtensionUpdateAPI pFolder, pExtensionSource
       if tFiles is empty then exit revIDEExtensionUpdateAPI
       put line 1 of tFiles into pExtensionSource
    end if
-   
+
    # Check timestamps to see if API  is out of date.
    local tNeedUpdate, tError, tSource
    put pFolder & slash & pExtensionSource into tSource
    put revIDEIsFilesetStale(tSource, \
          pFolder & slash & "api.lcdoc", false, tError) into tNeedUpdate
    if tNeedUpdate is empty then put true into tNeedUpdate
-   
+
    if tNeedUpdate then
       local tText
       if there is a stack tSource then
@@ -1478,10 +1601,10 @@ on revIDEExtensionUpdateAPI pFolder, pExtensionSource
       else
          put textDecode(url("binfile:" & tSource), "utf-8") into tText
       end if
-      
+
       local tAPI
       dispatch function "revDocsGenerateDocsFileFromText" to stack "revDocsParser" with tText, tSource
-      put the result into tAPI 
+      put the result into tAPI
       put textEncode(tAPI, "utf-8") into url ("binfile:" & pFolder & slash & "api.lcdoc")
       return "updated"
    end if
@@ -1493,11 +1616,11 @@ command revIDEExtensionCompile pFolder, pFile, pSupportFiles, pTargetFolder, pOu
       put pFolder & slash before line tLine of pSupportFiles
    end repeat
    put pFolder & slash before pFile
-   
+
    extensionCompile "", pFile, pSupportFiles, "", \
          revIDESpecialFolderPath("user extensions") & slash & \
          "interface", pTargetFolder, pOutputFilename
-   
+
    if the result is not empty then
       return the result for error
    end if
@@ -1508,7 +1631,7 @@ command revIDEExtensionMetadata pFolder, pFile, pType, @rDataA
    local tDataA, tResult
    revIDEExtensionFetchMetadata pFolder & slash & "manifest.xml", tDataA
    put the result into tResult
-   
+
    put tDataA into rDataA
    return tResult
 end revIDEExtensionMetadata
@@ -1524,24 +1647,38 @@ private command revIDEExtensionFetchMetadata pManifestPath, @rDataA
    if the result is not empty then
       return the result
    end if
-   
+
    # Make sure 'inspector' style metadata is processed
    __ProcessInspectorMetadata tDataA["standaloneSettings"]
-   
+
    put tDataA into rDataA
    return empty
 end revIDEExtensionFetchMetadata
 
-function revIDEExtensionFileData pID 
+/**
+Summary: gets file data for a given Extension ID
+
+Parameters:
+pExtensionID (string): An IDE Extension identifier
+
+Example:
+// display the "file" key, a file path to the Extension's bytcode module
+put revIDEExtensionFileData ( "com.livecode.widget.treeview") into tData; put tData["file"]
+
+// display the file "type" key, will be either 'lcb' or 'lcs'
+put revIDEExtensionFileData ( "com.livecode.widget.treeview") into tData; put tData["file"]
+
+**/
+function revIDEExtensionFileData pID
    # Get the internal cache index
    local tCacheIndex
    put __extensionCacheID("name", pID) into tCacheIndex
-   
+
    local tSourceType, tFolder, tFile
    put __extensionPropertyGet(tCacheIndex, "install_path") into tFolder
    put __extensionPropertyGet(tCacheIndex, "source_type") into tSourceType
    put __extensionPropertyGet(tCacheIndex, "file") into tFile
-   
+
    local tDataA
    put tSourceType into tDataA["type"]
    put tFolder & slash & tFile into tDataA["file"]
@@ -1563,30 +1700,52 @@ private command __UnloadExtension pCacheIndex, pSourceType, pSourceFile, pTypeId
    else
       put "unloaded" into tStatus
    end if
-   
+
    __extensionPropertySet pCacheIndex, "status", tStatus
    __extensionPropertySet pCacheIndex, "error", tError
    __extensionsChanged
 end __UnloadExtension
 
+/**
+Summary: unloads an Extension module for the given Extension ID
+
+Parameters:
+pExtensionID (string): An IDE Extension identifier
+
+Example:
+// Unload the Tree View Widget's module
+revIDEExtensionUnload  "com.livecode.widget.treeview"
+**/
 command revIDEExtensionUnload pKind
    local tCacheIndex
    put __extensionCacheID("name", pKind) into tCacheIndex
-   
+
    local tDataA
    put sExtensions[tCacheIndex] into tDataA
    __UnloadExtension tCacheIndex, tDataA["source_type"], \
          tDataA["source_file"], pKind
 end revIDEExtensionUnload
 
+/**
+Summary: List public handlers of a Library module for the given Extension ID
+
+Parameters:
+pExtensionID (string): An IDE Extension identifier
+
+Example:
+// Get a list of handlers from the Toast Library
+put revIDEExtensionLibraryHandlers( "com.livecode.library.toast")
+**/
 function revIDEExtensionLibraryHandlers pLibraryID
    local tCacheIndex
    put __extensionCacheID("name", pLibraryID) into tCacheIndex
-   
+
    return __extensionPropertyGet(tCacheIndex, "handlers")
 end revIDEExtensionLibraryHandlers
 
-command revIDEExtensionIconFromType pType, pID, @rIconName, @rIconPath         
+/**
+**/
+command revIDEExtensionIconFromType pType, pID, @rIconName, @rIconPath
    put revIDEExtensionProperty(pID, "svgIcon") into rIconPath
    switch pType
       case "widget"
@@ -1639,20 +1798,22 @@ on ideOpenStack pCard
 end ideOpenStack
 
 command revIDEExtensionLaunchSampleStack pSampleStack
-    // Check if the sample stack has already been opened,
-    // i.e. if its name is mapped in the array. If so, just
-    // open it.
-    if there is a stack (sOpenedStacksA[pSampleStack]) then
-        open stack sOpenedStacksA[pSampleStack]
-        exit revIDEExtensionLaunchSampleStack
-    end if
-    
-    // Otherwise open the stack from the file. Wait until we
-    // get the openStack message before emptying the filename
-    // otherwise we will get a long id clash
-    revIDESubscribe "ideOpenStack"
-    put pSampleStack into sSampleFileName
-    
-    ## Open the sample stack
-    open stack pSampleStack
+   -- put pSampleStack
+   // Check if the sample stack has already been opened,
+   // i.e. if its name is mapped in the array. If so, just
+   // open it.
+   if there is a stack (sOpenedStacksA[pSampleStack]) then
+         open stack sOpenedStacksA[pSampleStack]
+         exit revIDEExtensionLaunchSampleStack
+   end if
+   -- open stack sOpenedStacksA[pSampleStack]
+
+   // Otherwise open the stack from the file. Wait until we
+   // get the openStack message before emptying the filename
+   // otherwise we will get a long id clash
+   revIDESubscribe "ideOpenStack"
+   put pSampleStack into sSampleFileName
+   -- put sSampleFileName
+   ## Open the sample stack
+   open stack pSampleStack
 end revIDEExtensionLaunchSampleStack


### PR DESCRIPTION
(from OpenXTalk DPE) 
1-  Inline documentation was added.
2- This line:
 __extensionPropertySet tCacheIndex, "samples", __extensionSampleStacks(tId,pFolder)
Fixes problem where Extension pkg's sample stacks would not open from the contextal menu from in the Extension Manager extensions list.