### PR TITLE
fix linux build: cairo FreeType support and curl nghttp2 auto-detection

### DIFF
--- a/prebuilt/scripts/build-curl.sh
+++ b/prebuilt/scripts/build-curl.sh
@@ -12,7 +12,7 @@ CURL_CONFIG="--disable-debug \
             --enable-shared=no \
             --disable-sspi --disable-crypto-auth --disable-cookies \
 			--without-libpsl \
-            --without-gnutls --without-polarssl --without-nss --without-libssh2 --without-librtmp --without-libidn"
+            --without-gnutls --without-polarssl --without-nss --without-libssh2 --without-librtmp --without-libidn --without-nghttp2"
 
 # Grab the source for the library
 CURL_ROOT="https://curl.haxx.se/download/curl-"

--- a/prebuilt/scripts/build-libcairo.sh
+++ b/prebuilt/scripts/build-libcairo.sh
@@ -12,11 +12,24 @@ ARCHIVE_DESTINATION="cairo-${libcairo_VERSION}"
 FILE_DIRECTORY="../../thirdparty/${THIS}/src"
 INCLUDE_DIRECTORY="../../thirdparty/${THIS}/src"
 
+if [ "${PLATFORM}" == "mac" ] ; then
+	CAIRO_HAS_QUARTZ_FONT=1
+	CAIRO_HAS_QUARTZ_IMAGE_SURFACE=1
+	CAIRO_HAS_QUARTZ_SURFACE=1
+elif [ "${PLATFORM}" == "linux" ] ; then
+	CAIRO_HAS_FT_FONT=1
+	CAIRO_HAS_FC_FONT=1
+elif [ "${PLATFORM}" == "android" ] ; then
+	CAIRO_HAS_FT_FONT=1
+	CAIRO_HAS_FC_FONT=1
+fi
+
 fetchBinary
 untarBinary
 buildSrcLibrary
 # copy config.h
 cp -u ${BUILDDIR}/${ARCHIVE_DESTINATION}/build/*.h ${INCLUDE_DIRECTORY}
-# copy cairo-features.h
-cp -u ${BUILDDIR}/${ARCHIVE_DESTINATION}/build/src/*.h ${INCLUDE_DIRECTORY}
+# cairo-features.h is maintained in-tree with platform-conditional defines;
+# don't overwrite it with the meson-generated single-platform version.
+#cp -u ${BUILDDIR}/${ARCHIVE_DESTINATION}/build/src/*.h ${INCLUDE_DIRECTORY}
 

--- a/thirdparty/libcairo/src/cairo-features.h
+++ b/thirdparty/libcairo/src/cairo-features.h
@@ -19,11 +19,16 @@
 
 #define CAIRO_HAS_PS_SURFACE 1
 
+#if defined(__APPLE__)
 #define CAIRO_HAS_QUARTZ_FONT 1
-
 #define CAIRO_HAS_QUARTZ_IMAGE_SURFACE 1
-
 #define CAIRO_HAS_QUARTZ_SURFACE 1
+#endif
+
+#if defined(__linux__) || defined(__ANDROID__)
+#define CAIRO_HAS_FT_FONT 1
+#define CAIRO_HAS_FC_FONT 1
+#endif
 
 #define CAIRO_HAS_RECORDING_SURFACE 1
 


### PR DESCRIPTION
replaces #144 which was reverted.

`cairo-features.h` was generated on macOS and committed with Quartz backends but without `CAIRO_HAS_FT_FONT` / `CAIRO_HAS_FC_FONT`, so `revpdfprinter_lnx.cpp` fails to compile. the fix gates platform backends with `#if defined(__APPLE__)` / `#if defined(__linux__)` conditionals and stops `build-libcairo.sh` from overwriting the in-tree header with the meson-generated single-platform version — per @mwieder's suggestion in #144.

separately, `build-curl.sh` was missing `--without-nghttp2`, so on systems with `libnghttp2-dev` installed curl's configure auto-detects it and builds HTTP/2 support into `libcurl.a`. since nghttp2 isn't a managed dependency the link then fails with undefined `nghttp2_*` references. adding `--without-nghttp2` keeps the build reproducible.

verified with a clean `make clean-linux && make all-linux -j4` — full build succeeds and `put url "https://www.google.com"` returns data over TLS via `server-community`.