### PR TITLE
Add Linux AppImage packaging and CI release workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,6 +11,9 @@ on:
         options:
           - Release
           - Debug
+  push:
+    tags:
+      - 'v*'
 
 jobs:
 
@@ -41,7 +44,7 @@ jobs:
       - name: Build prebuilt third-party libraries
         run: make prebuilt-mac
         env:
-          BUILDTYPE: ${{ github.event.inputs.build_type }}
+          BUILDTYPE: ${{ inputs.build_type || 'Release' }}
 
       - name: Configure (GYP → Xcode projects)
         run: make config-mac
@@ -49,19 +52,17 @@ jobs:
       - name: Compile
         run: make compile-mac CODESIGN_IDENTITY="-"
         env:
-          BUILDTYPE: ${{ github.event.inputs.build_type }}
+          BUILDTYPE: ${{ inputs.build_type || 'Release' }}
 
       - name: Package (mac-bin)
         run: make package-mac-bin CODESIGN_IDENTITY="-"
         env:
-          BUILDTYPE: ${{ github.event.inputs.build_type }}
+          BUILDTYPE: ${{ inputs.build_type || 'Release' }}
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
-          name: HyperXTalk-macOS-ARM64-${{ github.event.inputs.build_type }}
-          # Upload the whole mac-bin folder — contains HyperXTalk.app plus
-          # all externals, support files, and standalone engine.
+          name: HyperXTalk-macOS-ARM64-${{ inputs.build_type || 'Release' }}
           path: mac-bin/
           retention-days: 30
 
@@ -82,12 +83,13 @@ jobs:
           sudo apt-get install -y \
             build-essential python3 python3-pip pkg-config \
             libssl-dev libcurl4-openssl-dev \
-            libgtk2.0-dev libglib2.0-dev \
+            libgtk-3-dev libglib2.0-dev \
             libpng-dev libjpeg-dev libfreetype6-dev libfontconfig1-dev \
             libx11-dev libxext-dev libxrender-dev \
             libxinerama-dev libxrandr-dev libxcb1-dev \
             libgif-dev libpcre3-dev zlib1g-dev \
-            default-jdk
+            default-jdk \
+            fuse libfuse2
 
       - name: Configure (GYP → Makefiles)
         run: ./config.sh --platform linux-x86_64
@@ -95,14 +97,29 @@ jobs:
       - name: Compile
         run: make compile-linux-x86_64
         env:
-          BUILDTYPE: ${{ github.event.inputs.build_type }}
+          BUILDTYPE: ${{ inputs.build_type || 'Release' }}
 
-      - name: Upload artifact
+      - name: Build AppImage
+        run: |
+          chmod +x packaging/linux/build-appimage.sh
+          ./packaging/linux/build-appimage.sh \
+            build-linux-x86_64/livecode \
+            "${{ inputs.build_type || 'Release' }}"
+
+      - name: Upload AppImage artifact
         uses: actions/upload-artifact@v4
         with:
-          name: HyperXTalk-Linux-x86_64-${{ github.event.inputs.build_type }}
+          name: HyperXTalk-Linux-x86_64-AppImage
+          path: build-linux-x86_64/livecode/HyperXTalk-*.AppImage
+          retention-days: 30
+
+      - name: Upload raw build artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: HyperXTalk-Linux-x86_64-${{ inputs.build_type || 'Release' }}
           path: linux-x86_64-bin/
           retention-days: 30
+          if-no-files-found: ignore
 
   # ─────────────────────────────────────────────────────────────────────────────
   # Windows x86_64
@@ -254,7 +271,47 @@ jobs:
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
-          name: HyperXTalk-Windows-x86_64-${{ github.event.inputs.build_type }}
+          name: HyperXTalk-Windows-x86_64-${{ inputs.build_type || 'Release' }}
           # Release output: HyperXTalk.exe, standalone-community.exe, externals, DB drivers
           path: build-win-x86_64\livecode\Release\
           retention-days: 30
+
+  # ─────────────────────────────────────────────────────────────────────────────
+  # Create GitHub Release (only on v* tags)
+  # ─────────────────────────────────────────────────────────────────────────────
+  release:
+    name: Create Release
+    if: startsWith(github.ref, 'refs/tags/v')
+    needs: [build-macos, build-linux, build-windows]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Download all artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: artifacts/
+
+      - name: Package artifacts for release
+        run: |
+          cd artifacts
+          # Zip the macOS build
+          if [ -d "HyperXTalk-macOS-ARM64-Release" ]; then
+            (cd HyperXTalk-macOS-ARM64-Release && zip -r ../HyperXTalk-macOS-ARM64.zip .)
+          fi
+          # The AppImage is already a single file
+          cp HyperXTalk-Linux-x86_64-AppImage/*.AppImage . 2>/dev/null || true
+          # Zip the Windows build
+          if [ -d "HyperXTalk-Windows-x86_64-Release" ]; then
+            (cd HyperXTalk-Windows-x86_64-Release && zip -r ../HyperXTalk-Windows-x86_64.zip .)
+          fi
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          generate_release_notes: true
+          files: |
+            artifacts/HyperXTalk-macOS-ARM64.zip
+            artifacts/HyperXTalk-*.AppImage
+            artifacts/HyperXTalk-Windows-x86_64.zip

--- a/packaging/linux/build-appimage.sh
+++ b/packaging/linux/build-appimage.sh
@@ -1,0 +1,135 @@
+#!/bin/bash
+# Build an AppImage for HyperXTalk from a completed Linux build.
+#
+# Usage:  ./packaging/linux/build-appimage.sh [BUILD_DIR] [BUILDTYPE]
+#
+# BUILD_DIR  defaults to build-linux-x86_64/livecode
+# BUILDTYPE  defaults to Debug
+#
+# Requires: appimagetool (downloaded automatically if not on PATH)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+BUILD_DIR="${1:-$REPO_ROOT/build-linux-x86_64/livecode}"
+BUILDTYPE="${2:-Debug}"
+OUT_DIR="$BUILD_DIR/out/$BUILDTYPE"
+
+if [ ! -x "$OUT_DIR/HyperXTalk" ]; then
+    echo "ERROR: $OUT_DIR/HyperXTalk not found — build first." >&2
+    exit 1
+fi
+
+# Read version from the version file (format: KEY = VALUE)
+VERSION="$(grep '^BUILD_SHORT_VERSION' "$REPO_ROOT/version" | sed 's/.*= *//')"
+VERSION="${VERSION:-0.0.0}"
+
+APPDIR="$BUILD_DIR/HyperXTalk.AppDir"
+rm -rf "$APPDIR"
+mkdir -p "$APPDIR/usr/bin" \
+         "$APPDIR/usr/share/applications" \
+         "$APPDIR/usr/share/icons/hicolor/48x48/apps"
+
+# The HyperXTalk engine resolves its tools path relative to its own binary
+# location.  It then looks for Toolset/home.livecodescript (the IDE entry
+# point), plus Resources/, Externals/, Documentation/, etc.  We lay out the
+# AppDir so that usr/bin/ contains the engine *and* all the IDE content it
+# expects to find as siblings.
+
+APPBIN="$APPDIR/usr/bin"
+IDE_DIR="$REPO_ROOT/ide"
+
+# --- Main binary ---
+cp "$OUT_DIR/HyperXTalk" "$APPBIN/"
+strip --strip-debug "$APPBIN/HyperXTalk" 2>/dev/null || true
+
+# --- IDE content (Toolset, Resources, Documentation, Plugins, etc.) ---
+for subdir in Toolset Resources Documentation Plugins Externals; do
+    if [ -d "$IDE_DIR/$subdir" ]; then
+        cp -a "$IDE_DIR/$subdir" "$APPBIN/"
+    fi
+done
+
+# --- Externals (.so plugins from the build) ---
+for so in "$OUT_DIR"/*.so; do
+    [ -f "$so" ] || continue
+    name="$(basename "$so")"
+    case "$name" in server-*) continue ;; esac
+    cp "$so" "$APPBIN/"
+    strip --strip-debug "$APPBIN/$name" 2>/dev/null || true
+done
+
+# --- Externals subdirectory from build (CEF etc) ---
+if [ -d "$OUT_DIR/Externals" ]; then
+    cp -a "$OUT_DIR/Externals/"* "$APPBIN/Externals/" 2>/dev/null || true
+fi
+
+# --- Packaged extensions ---
+if [ -d "$OUT_DIR/packaged_extensions" ]; then
+    mkdir -p "$APPBIN/packaged_extensions"
+    cp -a "$OUT_DIR/packaged_extensions/"* "$APPBIN/packaged_extensions/" 2>/dev/null || true
+fi
+
+# --- LCI modules ---
+if [ -d "$OUT_DIR/modules" ]; then
+    mkdir -p "$APPBIN/modules"
+    cp -a "$OUT_DIR/modules/"* "$APPBIN/modules/" 2>/dev/null || true
+fi
+
+# --- Desktop file ---
+cat > "$APPDIR/usr/share/applications/HyperXTalk.desktop" <<'DESKTOP'
+[Desktop Entry]
+Version=1.0
+Type=Application
+Name=HyperXTalk
+Comment=IDE for creating cross-platform applications
+Icon=hyperxtalk
+Exec=HyperXTalk %U
+Categories=Development;IDE;
+StartupWMClass=hyperxtalk
+DESKTOP
+
+# Symlink desktop file to AppDir root (required by AppImage)
+cp "$APPDIR/usr/share/applications/HyperXTalk.desktop" "$APPDIR/HyperXTalk.desktop"
+
+# --- Icon ---
+cp "$REPO_ROOT/Installer/application.png" \
+   "$APPDIR/usr/share/icons/hicolor/48x48/apps/hyperxtalk.png"
+# AppImage also needs an icon at the root
+cp "$REPO_ROOT/Installer/application.png" "$APPDIR/hyperxtalk.png"
+
+# --- AppRun ---
+cat > "$APPDIR/AppRun" <<'APPRUN'
+#!/bin/bash
+HERE="$(dirname "$(readlink -f "$0")")"
+export LD_LIBRARY_PATH="$HERE/usr/bin${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
+exec "$HERE/usr/bin/HyperXTalk" "$@"
+APPRUN
+chmod +x "$APPDIR/AppRun"
+
+# --- Obtain appimagetool ---
+ARCH="$(uname -m)"
+APPIMAGETOOL=""
+
+if command -v appimagetool >/dev/null 2>&1; then
+    APPIMAGETOOL="appimagetool"
+else
+    TOOL_PATH="$BUILD_DIR/appimagetool"
+    if [ ! -x "$TOOL_PATH" ]; then
+        echo "Downloading appimagetool..."
+        curl -fsSL -o "$TOOL_PATH" \
+            "https://github.com/AppImage/appimagetool/releases/download/continuous/appimagetool-${ARCH}.AppImage"
+        chmod +x "$TOOL_PATH"
+    fi
+    APPIMAGETOOL="$TOOL_PATH"
+fi
+
+# --- Build AppImage ---
+OUTPUT="$BUILD_DIR/HyperXTalk-${VERSION}-${ARCH}.AppImage"
+ARCH="$ARCH" "$APPIMAGETOOL" "$APPDIR" "$OUTPUT"
+
+echo ""
+echo "AppImage created: $OUTPUT"
+echo "Size: $(du -h "$OUTPUT" | cut -f1)"


### PR DESCRIPTION
New packaging/linux/build-appimage.sh script that bundles the engine,
IDE toolset, extensions, and plugins into a self-contained AppImage.
Updated CI workflow to build the AppImage as part of the Linux job and
added a release job that publishes all platform artifacts when a version
tag is pushed.

To trigger a build go to Actions > "Build HyperXTalk" > "Run workflow"
and pick Debug or Release. The AppImage will show up as a downloadable
artifact when the Linux job finishes.

To create a GitHub release with all three platforms push a version tag:

  git tag v0.9.11
  git push origin v0.9.11