### PR TITLE
Linux VLC: video embedding with X11 platform player

### DIFF
--- a/engine/engine-sources.gypi
+++ b/engine/engine-sources.gypi
@@ -699,6 +699,7 @@
 			'src/lnxkeymapping.cpp',
 			'src/lnxmisc.cpp',
 			'src/lnxmplayer.cpp',
+			'src/lnx-core-compat.cpp',
 			'src/lnxpsprinter.cpp',
 			'src/lnxspec.cpp',
 			'src/lnxstack.cpp',
@@ -1247,7 +1248,8 @@
 				{
 					'sources!':
 					[
-						'src/player-platform.cpp',
+						'src/player-legacy.cpp',
+						'src/lnxmplayer.cpp',
 						'src/tilecachegl.cpp',
 						'src/tilecachegl3.x.cpp',
 						'src/glcontext.cpp',

--- a/engine/src/dsklnx.cpp
+++ b/engine/src/dsklnx.cpp
@@ -459,15 +459,12 @@ static void handle_signal(int sig)
         break;
     case SIGCHLD:
         {
-#if defined(_LINUX_DESKTOP)
+#ifdef FEATURE_MPLAYER
             MCPlayerHandle t_player = MCplayers;
-            // If we have some players waiting then deal with these first
             waitedpid = -1;
             if (t_player.IsValid())
             {
                 waitedpid = wait(NULL);
-                // Moving these two lines half fixes bug 5966 - however it still isn't quite right
-                // as there will still be some interaction between a player and shell command
                 while(t_player.IsValid())
                 {
                     if (t_player.IsValid() && waitedpid == t_player->getpid())
@@ -485,10 +482,6 @@ static void handle_signal(int sig)
             }
             else
             {
-                // Check to see if we have created a video window. If we have got to here it means
-                // that we could not start mplayer -- so the child thread has exited, but the player
-                // object has not had a chance to be created yet. TODO - investigate if there is a
-                // cleaner way of dealing with this situation.
                 if ( MClastvideowindow != DNULL )
                 {
                     gdk_window_hide(MClastvideowindow);
@@ -500,7 +493,9 @@ static void handle_signal(int sig)
                     MCS_checkprocesses();
                 }
             }
-#endif /* LINUX_DESKTOP */
+#else
+            MCS_checkprocesses();
+#endif
         }
         break;
     case SIGALRM:

--- a/engine/src/linux.stubs
+++ b/engine/src/linux.stubs
@@ -24,6 +24,11 @@ X11 libX11.so.6
 	XUnmapWindow: (pointer, integer) -> ()
 	XDestroyWindow: (pointer, integer) -> ()
 	XCreateSimpleWindow: (pointer, integer, integer, integer, integer, integer, integer, integer, integer) -> (integer)
+	XCreateWindow: (pointer, integer, integer, integer, integer, integer, integer, integer, integer, pointer, integer, pointer) -> (integer)
+	XCreateColormap: (pointer, integer, pointer, integer) -> (integer)
+	XFreeColormap: (pointer, integer) -> ()
+	XMatchVisualInfo: (pointer, integer, integer, integer, pointer) -> (integer)
+	XDefaultScreen: (pointer) -> (integer)
 	XFlush: (pointer) -> ()
 
 Xinerama libXinerama.so.1

--- a/engine/src/linux.stubs
+++ b/engine/src/linux.stubs
@@ -23,6 +23,8 @@ X11 libX11.so.6
 	XMapWindow: (pointer, integer) -> ()
 	XUnmapWindow: (pointer, integer) -> ()
 	XDestroyWindow: (pointer, integer) -> ()
+	XCreateSimpleWindow: (pointer, integer, integer, integer, integer, integer, integer, integer, integer) -> (integer)
+	XFlush: (pointer) -> ()
 
 Xinerama libXinerama.so.1
 	XineramaIsActive: (pointer) -> (integer)

--- a/engine/src/lnx-core-compat.cpp
+++ b/engine/src/lnx-core-compat.cpp
@@ -1,0 +1,73 @@
+/* Copyright (C) 2024 HyperXTalk Contributors
+
+This file is part of HyperXTalk.
+
+HyperXTalk is free software; you can redistribute it and/or modify it under
+the terms of the GNU General Public License v3 as published by the Free
+Software Foundation.  */
+
+#include "prefix.h"
+
+#include "globdefs.h"
+#include "platform.h"
+#include "platform-internal.h"
+
+#include "player.h"
+#include "globals.h"
+
+void MCPlatformBreakWait(void)
+{
+    MCscreen->pingwait();
+}
+
+bool MCPlatformWaitForEvent(double duration, bool blocking)
+{
+    bool t_dispatch = !blocking;
+    return MCscreen->wait(duration, t_dispatch, false);
+}
+
+static MCPlayer *find_player(MCPlatformPlayerRef p_player)
+{
+    for (MCPlayerHandle t_player = MCplayers; t_player.IsValid();
+         t_player = t_player->getnextplayer())
+    {
+        if (t_player->getplatformplayer() == p_player)
+            return t_player;
+    }
+    return nil;
+}
+
+void MCPlatformCallbackSendPlayerFrameChanged(MCPlatformPlayerRef p_player)
+{
+    MCPlayer *t_player = find_player(p_player);
+    if (t_player == nil)
+        return;
+    t_player->layer_redrawall();
+    MCPlatformBreakWait();
+}
+
+void MCPlatformCallbackSendPlayerMarkerChanged(MCPlatformPlayerRef p_player, MCPlatformPlayerDuration p_time)
+{
+    MCPlayer *t_player = find_player(p_player);
+    if (t_player == nil)
+        return;
+    t_player->markerchanged(p_time);
+}
+
+void MCPlatformCallbackSendPlayerCurrentTimeChanged(MCPlatformPlayerRef p_player)
+{
+    MCPlayer *t_player = find_player(p_player);
+    if (t_player == nil)
+        return;
+    t_player->currenttimechanged();
+}
+
+void MCPlatformCallbackSendPlayerFinished(MCPlatformPlayerRef p_player)
+{
+    MCPlayer *t_player = find_player(p_player);
+    if (t_player == nil)
+        return;
+    MCPlatformBreakWait();
+    t_player->layer_redrawall();
+    t_player->moviefinished();
+}

--- a/engine/src/mcio.cpp
+++ b/engine/src/mcio.cpp
@@ -89,7 +89,7 @@ void IO_cleanprocesses()
 		        && (MCprocesses[i].ihandle == NULL
 		            || MCS_eof(MCprocesses[i].ihandle)))
 		{
-#ifdef X11
+#ifdef FEATURE_MPLAYER
 			if (MCprocesses[i].mode == OM_VCLIP)
 			{
 				MCPlayerHandle t_player = MCplayers;

--- a/engine/src/player-platform.cpp
+++ b/engine/src/player-platform.cpp
@@ -1502,6 +1502,13 @@ Boolean MCPlayer::prepare(MCStringRef options)
 #if defined(TARGET_PLATFORM_WINDOWS)
 	if (!MCPlatformPlayerSetNativeParentView(m_platform_player, getstack()->getrealwindow()))
 		return False;
+#elif defined(TARGET_PLATFORM_LINUX)
+	if (!MCPlatformPlayerSetNativeParentView(m_platform_player, getstack()->getwindow()))
+		return False;
+	{
+		MCRectangle t_rect = getrect();
+		MCPlatformSetPlayerProperty(m_platform_player, kMCPlatformPlayerPropertyRect, kMCPlatformPropertyTypeRectangle, &t_rect);
+	}
 #endif
 	
     // PM-2015-01-26: [[ Bug 14435 ]] Avoid prepending the defaultFolder or the stack folder

--- a/engine/src/player-platform.cpp
+++ b/engine/src/player-platform.cpp
@@ -889,6 +889,7 @@ MCRectangle MCPlayer::getactiverect(void)
 void MCPlayer::open()
 {
     MCControl::open();
+    fprintf(stderr, "[VLC] MCPlayer::open() opened=%d\n", opened);
     prepare(kMCEmptyString);
 	attachplayer();
 }
@@ -902,6 +903,7 @@ void MCPlayer::close()
 
 	if (opened == 0)
 	{
+		fprintf(stderr, "[VLC] MCPlayer::close() releasing platform player (opened=0)\n");
 		state |= CS_CLOSING;
 		playstop();
 		state &= ~CS_CLOSING;
@@ -913,6 +915,10 @@ void MCPlayer::close()
 			MCPlatformPlayerRelease(m_platform_player);
 			m_platform_player = nullptr;
 		}
+	}
+	else
+	{
+		fprintf(stderr, "[VLC] MCPlayer::close() opened=%d, keeping player\n", opened);
 	}
 }
 
@@ -1593,13 +1599,20 @@ void MCPlayer::attachplayer()
 {
     if (m_platform_player == nil)
         return;
-	
+
 	if (getflag(F_ALWAYS_BUFFER))
 		return;
-	
+
+#if defined(TARGET_PLATFORM_LINUX)
+	// On Linux, SetNativeParentView() in prepare() already created a GDK
+	// child window and passed its XID to libvlc_media_player_set_xwindow().
+	// The Mac-style native layer attach path is not used.
+	return;
+#endif
+
 	if (getNativeLayer() != nil)
 		return;
-	
+
 	SetNativeView(MCPlatformPlayerGetNativeView(m_platform_player));
 }
 

--- a/engine/src/player-platform.cpp
+++ b/engine/src/player-platform.cpp
@@ -889,7 +889,6 @@ MCRectangle MCPlayer::getactiverect(void)
 void MCPlayer::open()
 {
     MCControl::open();
-    fprintf(stderr, "[VLC] MCPlayer::open() opened=%d\n", opened);
     prepare(kMCEmptyString);
 	attachplayer();
 }
@@ -903,7 +902,6 @@ void MCPlayer::close()
 
 	if (opened == 0)
 	{
-		fprintf(stderr, "[VLC] MCPlayer::close() releasing platform player (opened=0)\n");
 		state |= CS_CLOSING;
 		playstop();
 		state &= ~CS_CLOSING;
@@ -915,10 +913,6 @@ void MCPlayer::close()
 			MCPlatformPlayerRelease(m_platform_player);
 			m_platform_player = nullptr;
 		}
-	}
-	else
-	{
-		fprintf(stderr, "[VLC] MCPlayer::close() opened=%d, keeping player\n", opened);
 	}
 }
 
@@ -1242,7 +1236,15 @@ void MCPlayer::syncbuffering(MCContext *p_dc)
     t_should_buffer = t_should_buffer || getstack() -> gettool(this) != T_BROWSE;
 	
 	if (m_platform_player != nil)
+	{
+#if defined(TARGET_PLATFORM_LINUX)
+		MCRectangle t_video_rect = getactiverect();
+		if (getflag(F_SHOW_CONTROLLER) && t_video_rect.height > CONTROLLER_HEIGHT)
+			t_video_rect.height -= CONTROLLER_HEIGHT;
+		MCPlatformSetPlayerProperty(m_platform_player, kMCPlatformPlayerPropertyRect, kMCPlatformPropertyTypeRectangle, &t_video_rect);
+#endif
 		MCPlatformSetPlayerProperty(m_platform_player, kMCPlatformPlayerPropertyOffscreen, kMCPlatformPropertyTypeBool, &t_should_buffer);
+	}
 }
 
 // MW-2007-08-14: [[ Bug 1949 ]] On Windows ensure we load and unload QT if not
@@ -1511,10 +1513,6 @@ Boolean MCPlayer::prepare(MCStringRef options)
 #elif defined(TARGET_PLATFORM_LINUX)
 	if (!MCPlatformPlayerSetNativeParentView(m_platform_player, getstack()->getwindow()))
 		return False;
-	{
-		MCRectangle t_rect = getrect();
-		MCPlatformSetPlayerProperty(m_platform_player, kMCPlatformPlayerPropertyRect, kMCPlatformPropertyTypeRectangle, &t_rect);
-	}
 #endif
 	
     // PM-2015-01-26: [[ Bug 14435 ]] Avoid prepending the defaultFolder or the stack folder
@@ -1553,7 +1551,16 @@ Boolean MCPlayer::prepare(MCStringRef options)
     }
 	
 	resize(t_movie_rect);
-	
+
+#if defined(TARGET_PLATFORM_LINUX)
+	{
+		MCRectangle t_video_rect = getactiverect();
+		if (getflag(F_SHOW_CONTROLLER) && t_video_rect.height > CONTROLLER_HEIGHT)
+			t_video_rect.height -= CONTROLLER_HEIGHT;
+		MCPlatformSetPlayerProperty(m_platform_player, kMCPlatformPlayerPropertyRect, kMCPlatformPropertyTypeRectangle, &t_video_rect);
+	}
+#endif
+
 	bool t_looping, t_play_selection, t_show_selection, t_mirrored;
 	
 	t_looping = getflag(F_LOOPING);

--- a/engine/src/sysdefs.h
+++ b/engine/src/sysdefs.h
@@ -65,7 +65,7 @@ along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
 #define PLATFORM_STRING "Linux"
 
 #define MCSSL
-#define FEATURE_MPLAYER
+#define FEATURE_PLATFORM_PLAYER
 #define FEATURE_NOTIFY 1
 
 #elif defined(_WINDOWS_SERVER)

--- a/engine/src/vlc-player.cpp
+++ b/engine/src/vlc-player.cpp
@@ -1213,12 +1213,11 @@ bool MCVLCPlayer::EnsureVLCInstance()
     }
 
     const char *t_args[] = {
-        "--no-xlib",
         "--quiet",
         "--no-osd",
         "--no-stats",
     };
-    s_vlc_instance = libvlc_new(4, t_args);
+    s_vlc_instance = libvlc_new(3, t_args);
 #endif
 
     if (s_vlc_instance == nullptr)
@@ -1381,6 +1380,14 @@ MCVLCPlayer::~MCVLCPlayer()
         }
         m_view = nullptr;
     }
+#elif defined(TARGET_PLATFORM_LINUX)
+    if (m_view != nullptr)
+    {
+        x11::Display *t_dpy = x11::gdk_x11_display_get_xdisplay(
+            gdk_display_get_default());
+        x11::XDestroyWindow(t_dpy, (x11::Window)(uintptr_t)m_view);
+        m_view = nullptr;
+    }
 #endif
 
     MCMemoryDeleteArray(m_markers);
@@ -1438,15 +1445,18 @@ void MCVLCPlayer::Synchronize()
 #elif defined(TARGET_PLATFORM_LINUX)
     if (m_view != nullptr)
     {
-        GdkWindow *t_win = (GdkWindow *)m_view;
+        x11::Display *t_dpy = x11::gdk_x11_display_get_xdisplay(
+            gdk_display_get_default());
+        x11::Window t_win = (x11::Window)(uintptr_t)m_view;
         int t_w = m_rect.width  > 0 ? m_rect.width  : 1;
         int t_h = m_rect.height > 0 ? m_rect.height : 1;
-        gdk_window_move_resize(t_win,
+        x11::XMoveResizeWindow(t_dpy, t_win,
                                m_rect.x, m_rect.y, t_w, t_h);
         if (m_visible)
-            gdk_window_show_unraised(t_win);
+            x11::XMapWindow(t_dpy, t_win);
         else
-            gdk_window_hide(t_win);
+            x11::XUnmapWindow(t_dpy, t_win);
+        x11::XFlush(t_dpy);
     }
 #endif
 }
@@ -1464,10 +1474,8 @@ void MCVLCPlayer::AttachNativeView()
         libvlc_media_player_set_hwnd(m_player, m_view);
 #elif defined(TARGET_PLATFORM_LINUX)
     if (m_view != nullptr)
-    {
-        uint32_t t_xid = x11::gdk_x11_drawable_get_xid((GdkDrawable *)m_view);
-        libvlc_media_player_set_xwindow(m_player, t_xid);
-    }
+        libvlc_media_player_set_xwindow(m_player,
+                                        (uint32_t)(uintptr_t)m_view);
 #endif
 }
 
@@ -1760,41 +1768,35 @@ bool MCVLCPlayer::SetNativeParentView(void *p_parent_view)
         return false;
     }
 
-    GdkWindow *t_parent = (GdkWindow *)p_parent_view;
-    GdkWindowAttr t_wa;
-    t_wa.colormap    = gdk_drawable_get_colormap((GdkDrawable *)t_parent);
-    t_wa.x           = m_rect.x;
-    t_wa.y           = m_rect.y;
-    t_wa.width       = m_rect.width  > 0 ? m_rect.width  : 1;
-    t_wa.height      = m_rect.height > 0 ? m_rect.height : 1;
-    t_wa.event_mask  = 0;
-    t_wa.wclass      = GDK_INPUT_OUTPUT;
-    t_wa.window_type = GDK_WINDOW_CHILD;
+    // Use raw X11 child window instead of GDK — VLC's xcb video output
+    // does not render into GDK-managed windows.
+    GdkWindow *t_gdk_parent = (GdkWindow *)p_parent_view;
+    x11::Window t_parent_xid = x11::gdk_x11_drawable_get_xid(
+        (GdkDrawable *)t_gdk_parent);
+    x11::Display *t_dpy = x11::gdk_x11_display_get_xdisplay(
+        gdk_display_get_default());
 
-    GdkWindowAttributesType t_mask = (GdkWindowAttributesType)(GDK_WA_X | GDK_WA_Y);
-    if (t_wa.colormap != nullptr)
-        t_mask = (GdkWindowAttributesType)(t_mask | GDK_WA_COLORMAP);
-
-    GdkWindow *t_win = gdk_window_new(t_parent, &t_wa, t_mask);
-    if (t_win == nullptr)
-    {
-        vlc_log("[VLC] SetNativeParentView: gdk_window_new FAILED\n");
-        return false;
-    }
-
-    // Prevent GDK from painting a background over VLC's X11 rendering.
-    gdk_window_set_back_pixmap(t_win, NULL, FALSE);
+    int t_x = m_rect.x;
+    int t_y = m_rect.y;
+    int t_w = m_rect.width  > 0 ? m_rect.width  : 1;
+    int t_h = m_rect.height > 0 ? m_rect.height : 1;
 
     if (m_view != nullptr)
-        gdk_window_destroy((GdkWindow *)m_view);
+    {
+        x11::XDestroyWindow(t_dpy, (x11::Window)(uintptr_t)m_view);
+        m_view = nullptr;
+    }
 
-    m_view = t_win;
-    uint32_t t_xid = x11::gdk_x11_drawable_get_xid((GdkDrawable *)t_win);
-    vlc_log("[VLC] SetNativeParentView: xid=%u view=%p\n", t_xid, t_win);
-    libvlc_media_player_set_xwindow(m_player, t_xid);
+    x11::Window t_win = x11::XCreateSimpleWindow(
+        t_dpy, t_parent_xid, t_x, t_y, t_w, t_h, 0, 0, 0);
+    x11::XMapWindow(t_dpy, t_win);
+    x11::XFlush(t_dpy);
 
-    if (m_visible)
-        gdk_window_show_unraised(t_win);
+    m_view = (void *)(uintptr_t)t_win;
+
+    vlc_log("[VLC] SetNativeParentView: xid=%lu view=%p\n",
+            (unsigned long)t_win, m_view);
+    libvlc_media_player_set_xwindow(m_player, (uint32_t)t_win);
 #elif defined(TARGET_PLATFORM_MACOS_X)
     // Add the player view as a subview of the stack window's content view.
     MCVLCReparentNSView(m_view, p_parent_view);
@@ -2180,7 +2182,7 @@ void MCVLCPlayer::Start(double rate)
 #if defined(TARGET_PLATFORM_LINUX)
     if (m_view != nullptr)
     {
-        uint32_t t_xid = x11::gdk_x11_drawable_get_xid((GdkDrawable *)m_view);
+        uint32_t t_xid = (uint32_t)(uintptr_t)m_view;
         libvlc_media_player_set_xwindow(m_player, t_xid);
         vlc_log("[VLC] Start: re-set xwindow=%u\n", t_xid);
     }

--- a/engine/src/vlc-player.cpp
+++ b/engine/src/vlc-player.cpp
@@ -1782,6 +1782,9 @@ bool MCVLCPlayer::SetNativeParentView(void *p_parent_view)
         return false;
     }
 
+    // Prevent GDK from painting a background over VLC's X11 rendering.
+    gdk_window_set_back_pixmap(t_win, NULL, FALSE);
+
     if (m_view != nullptr)
         gdk_window_destroy((GdkWindow *)m_view);
 
@@ -2174,6 +2177,14 @@ void MCVLCPlayer::Start(double rate)
     }
 #endif
 
+#if defined(TARGET_PLATFORM_LINUX)
+    if (m_view != nullptr)
+    {
+        uint32_t t_xid = x11::gdk_x11_drawable_get_xid((GdkDrawable *)m_view);
+        libvlc_media_player_set_xwindow(m_player, t_xid);
+        vlc_log("[VLC] Start: re-set xwindow=%u\n", t_xid);
+    }
+#endif
     libvlc_media_player_play(m_player);
     libvlc_media_player_set_rate(m_player, (float)rate);
     m_playing = true;
@@ -2491,11 +2502,13 @@ void MCVLCPlayer::GetProperty(MCPlatformPlayerProperty p_property,
             break;
 
         case kMCPlatformPlayerPropertyCurrentTime:
+        {
+            libvlc_time_t t_time = (m_player != nullptr)
+                ? libvlc_media_player_get_time(m_player) : 0;
             *(MCPlatformPlayerDuration *)r_value =
-                (m_player != nullptr)
-                    ? (MCPlatformPlayerDuration)libvlc_media_player_get_time(m_player)
-                    : 0;
+                (t_time >= 0) ? (MCPlatformPlayerDuration)t_time : 0;
             break;
+        }
 
         case kMCPlatformPlayerPropertyStartTime:
             *(MCPlatformPlayerDuration *)r_value = m_selection_start;

--- a/engine/src/vlc-player.cpp
+++ b/engine/src/vlc-player.cpp
@@ -37,6 +37,16 @@ Software Foundation.  */
 #include <dlfcn.h>    // dladdr / Dl_info — used in EnsureVLCInstance to locate the bundle
 #include <unistd.h>   // access() — used to probe candidate plugin directories
 #include <stdlib.h>   // setenv() — used to set VLC_PLUGIN_PATH before libvlc_new
+#elif defined(TARGET_PLATFORM_LINUX)
+#include <unistd.h>   // readlink, access
+#include <stdlib.h>   // setenv
+#include <limits.h>   // PATH_MAX
+// gdk/gdkx.h can't be included directly — its X11 types clash with the
+// engine's GdkWindow* typedefs in sysdefs.h.  Wrap it in a namespace like
+// lnxprefix.h does, so we can call x11::gdk_x11_drawable_get_xid().
+namespace x11 {
+#include <gdk/gdkx.h>
+}
 #endif
 
 // ---------------------------------------------------------------------------
@@ -1168,9 +1178,42 @@ bool MCVLCPlayer::EnsureVLCInstance()
         RemoveVectoredExceptionHandler(t_veh);
     }
 #else
-    // Linux
+    // Linux — probe for bundled VLC plugins, fall back to system paths.
+    //
+    // Layout matches Windows/Mac: <exe_dir>/vlc-plugins/plugins/ contains
+    // the codec/demux/output .so files.  The AppImage build script copies
+    // them from /usr/lib/<arch>/vlc/plugins/.
+    //
+    // VLC_PLUGIN_PATH is the correct mechanism for both libVLC 3 and 4.
+    {
+        char t_exe[PATH_MAX];
+        ssize_t t_len = readlink("/proc/self/exe", t_exe, sizeof(t_exe) - 1);
+        if (t_len > 0)
+        {
+            t_exe[t_len] = '\0';
+            char *t_sep = strrchr(t_exe, '/');
+            if (t_sep != nullptr)
+                *t_sep = '\0';
+
+            char t_probe[PATH_MAX];
+            snprintf(t_probe, sizeof(t_probe),
+                     "%s/vlc-plugins/plugins", t_exe);
+            if (access(t_probe, F_OK) == 0)
+            {
+                setenv("VLC_PLUGIN_PATH", t_probe, 1);
+            }
+            else
+            {
+                snprintf(t_probe, sizeof(t_probe),
+                         "%s/vlc-plugins", t_exe);
+                if (access(t_probe, F_OK) == 0)
+                    setenv("VLC_PLUGIN_PATH", t_probe, 1);
+            }
+        }
+    }
+
     const char *t_args[] = {
-        "--no-xlib",          // avoid X threading issues on Linux
+        "--no-xlib",
         "--quiet",
         "--no-osd",
         "--no-stats",
@@ -1271,8 +1314,12 @@ MCVLCPlayer::MCVLCPlayer()
 
 MCVLCPlayer::~MCVLCPlayer()
 {
+#if defined(TARGET_PLATFORM_WINDOWS)
     vlc_log("[VLC] ~MCVLCPlayer() destructing m_view=%p m_play_pending=%d\n",
             m_view, (int)m_play_pending);
+#else
+    vlc_log("[VLC] ~MCVLCPlayer() destructing m_view=%p\n", m_view);
+#endif
 
     // Stop any pending offscreen decode.
     if (m_offscreen_bitmap != nullptr)
@@ -1392,9 +1439,10 @@ void MCVLCPlayer::Synchronize()
     if (m_view != nullptr)
     {
         GdkWindow *t_win = (GdkWindow *)m_view;
+        int t_w = m_rect.width  > 0 ? m_rect.width  : 1;
+        int t_h = m_rect.height > 0 ? m_rect.height : 1;
         gdk_window_move_resize(t_win,
-                               m_rect.x, m_rect.y,
-                               m_rect.width, m_rect.height);
+                               m_rect.x, m_rect.y, t_w, t_h);
         if (m_visible)
             gdk_window_show_unraised(t_win);
         else
@@ -1415,9 +1463,11 @@ void MCVLCPlayer::AttachNativeView()
     if (m_view != nullptr)
         libvlc_media_player_set_hwnd(m_player, m_view);
 #elif defined(TARGET_PLATFORM_LINUX)
-    // XID is stored as a uintptr_t in m_view.
-    libvlc_media_player_set_xwindow(m_player,
-                                    (uint32_t)(uintptr_t)m_view);
+    if (m_view != nullptr)
+    {
+        uint32_t t_xid = x11::gdk_x11_drawable_get_xid((GdkDrawable *)m_view);
+        libvlc_media_player_set_xwindow(m_player, t_xid);
+    }
 #endif
 }
 
@@ -1701,13 +1751,18 @@ bool MCVLCPlayer::SetNativeParentView(void *p_parent_view)
     vlc_log("[VLC] HWND %p given to libvlc_media_player_set_hwnd\n",
             (void *)m_view);
 #elif defined(TARGET_PLATFORM_LINUX)
-    // Obtain the X11 window ID from the GDK parent window.
+    vlc_log("[VLC] SetNativeParentView: parent=%p rect=(%d,%d,%dx%d)\n",
+            p_parent_view, m_rect.x, m_rect.y, m_rect.width, m_rect.height);
+
     if (p_parent_view == nullptr)
+    {
+        vlc_log("[VLC] SetNativeParentView: parent is NULL\n");
         return false;
+    }
 
     GdkWindow *t_parent = (GdkWindow *)p_parent_view;
     GdkWindowAttr t_wa;
-    t_wa.colormap    = nullptr;
+    t_wa.colormap    = gdk_drawable_get_colormap((GdkDrawable *)t_parent);
     t_wa.x           = m_rect.x;
     t_wa.y           = m_rect.y;
     t_wa.width       = m_rect.width  > 0 ? m_rect.width  : 1;
@@ -1716,16 +1771,23 @@ bool MCVLCPlayer::SetNativeParentView(void *p_parent_view)
     t_wa.wclass      = GDK_INPUT_OUTPUT;
     t_wa.window_type = GDK_WINDOW_CHILD;
 
-    GdkWindow *t_win = gdk_window_new(t_parent, &t_wa,
-                                      GDK_WA_X | GDK_WA_Y);
+    GdkWindowAttributesType t_mask = (GdkWindowAttributesType)(GDK_WA_X | GDK_WA_Y);
+    if (t_wa.colormap != nullptr)
+        t_mask = (GdkWindowAttributesType)(t_mask | GDK_WA_COLORMAP);
+
+    GdkWindow *t_win = gdk_window_new(t_parent, &t_wa, t_mask);
     if (t_win == nullptr)
+    {
+        vlc_log("[VLC] SetNativeParentView: gdk_window_new FAILED\n");
         return false;
+    }
 
     if (m_view != nullptr)
         gdk_window_destroy((GdkWindow *)m_view);
 
     m_view = t_win;
-    uint32_t t_xid = gdk_x11_drawable_get_xid(t_win);
+    uint32_t t_xid = x11::gdk_x11_drawable_get_xid((GdkDrawable *)t_win);
+    vlc_log("[VLC] SetNativeParentView: xid=%u view=%p\n", t_xid, t_win);
     libvlc_media_player_set_xwindow(m_player, t_xid);
 
     if (m_visible)
@@ -2208,10 +2270,15 @@ void MCVLCPlayer::SetProperty(MCPlatformPlayerProperty p_property,
         // --- geometry ---
         case kMCPlatformPlayerPropertyRect:
             m_rect = *(MCRectangle *)p_value;
+#if defined(TARGET_PLATFORM_WINDOWS)
             vlc_log("[VLC] SetProperty(rect): m_rect=(%d,%d,%dx%d) "
                     "m_play_pending=%d\n",
                     m_rect.x, m_rect.y, m_rect.width, m_rect.height,
                     (int)m_play_pending);
+#else
+            vlc_log("[VLC] SetProperty(rect): m_rect=(%d,%d,%dx%d)\n",
+                    m_rect.x, m_rect.y, m_rect.width, m_rect.height);
+#endif
 #if defined(TARGET_PLATFORM_WINDOWS)
             // Primary deferred-play trigger: the engine has set the player's
             // bounds.  If a play is waiting on the HWND becoming non-zero, fire

--- a/engine/src/vlc-player.cpp
+++ b/engine/src/vlc-player.cpp
@@ -1216,8 +1216,9 @@ bool MCVLCPlayer::EnsureVLCInstance()
         "--quiet",
         "--no-osd",
         "--no-stats",
+        "--vout=xcb_x11",
     };
-    s_vlc_instance = libvlc_new(3, t_args);
+    s_vlc_instance = libvlc_new(4, t_args);
 #endif
 
     if (s_vlc_instance == nullptr)
@@ -1255,6 +1256,9 @@ MCVLCPlayer::MCVLCPlayer()
     : m_player(nullptr),
       m_media(nullptr),
       m_view(nullptr),
+#if defined(TARGET_PLATFORM_LINUX)
+      m_colormap(0),
+#endif
       m_rect(MCRectangleMake(0, 0, 0, 0)),
       m_visible(true),
       m_offscreen(false),
@@ -1386,6 +1390,11 @@ MCVLCPlayer::~MCVLCPlayer()
         x11::Display *t_dpy = x11::gdk_x11_display_get_xdisplay(
             gdk_display_get_default());
         x11::XDestroyWindow(t_dpy, (x11::Window)(uintptr_t)m_view);
+        if (m_colormap != 0)
+        {
+            x11::XFreeColormap(t_dpy, m_colormap);
+            m_colormap = 0;
+        }
         m_view = nullptr;
     }
 #endif
@@ -1786,9 +1795,49 @@ bool MCVLCPlayer::SetNativeParentView(void *p_parent_view)
         x11::XDestroyWindow(t_dpy, (x11::Window)(uintptr_t)m_view);
         m_view = nullptr;
     }
+    if (m_colormap != 0)
+    {
+        x11::XFreeColormap(t_dpy, m_colormap);
+        m_colormap = 0;
+    }
 
-    x11::Window t_win = x11::XCreateSimpleWindow(
-        t_dpy, t_parent_xid, t_x, t_y, t_w, t_h, 0, 0, 0);
+    // Use a 24-bit (non-ARGB) visual to prevent transparency under
+    // compositing WMs.  GDK may use a 32-bit ARGB visual for its
+    // windows; child windows inherit that visual, and VLC's xcb output
+    // leaves the alpha byte at 0 — making every pixel transparent.
+    x11::Window t_win = 0;
+    x11::XVisualInfo t_vinfo;
+    int t_screen = x11::XDefaultScreen(t_dpy);
+    if (x11::XMatchVisualInfo(t_dpy, t_screen, 24, TrueColor, &t_vinfo))
+    {
+        m_colormap = x11::XCreateColormap(
+            t_dpy, t_parent_xid, t_vinfo.visual, AllocNone);
+        x11::XSetWindowAttributes t_attrs;
+        memset(&t_attrs, 0, sizeof(t_attrs));
+        t_attrs.background_pixel = 0;
+        t_attrs.border_pixel = 0;
+        t_attrs.colormap = m_colormap;
+        t_win = x11::XCreateWindow(
+            t_dpy, t_parent_xid, t_x, t_y, t_w, t_h,
+            0, t_vinfo.depth, InputOutput, t_vinfo.visual,
+            CWBackPixel | CWBorderPixel | CWColormap, &t_attrs);
+    }
+    else
+    {
+        t_win = x11::XCreateSimpleWindow(
+            t_dpy, t_parent_xid, t_x, t_y, t_w, t_h, 0, 0, 0);
+    }
+
+    if (t_win == 0)
+    {
+        if (m_colormap != 0)
+        {
+            x11::XFreeColormap(t_dpy, m_colormap);
+            m_colormap = 0;
+        }
+        return false;
+    }
+
     x11::XMapWindow(t_dpy, t_win);
     x11::XFlush(t_dpy);
 
@@ -2347,6 +2396,15 @@ void MCVLCPlayer::SetProperty(MCPlatformPlayerProperty p_property,
             if (t_new_offscreen == m_offscreen)
                 break;
             m_offscreen = t_new_offscreen;
+#if defined(TARGET_PLATFORM_LINUX)
+            if (m_offscreen && m_view != nullptr)
+            {
+                x11::Display *t_dpy = x11::gdk_x11_display_get_xdisplay(
+                    gdk_display_get_default());
+                x11::XUnmapWindow(t_dpy, (x11::Window)(uintptr_t)m_view);
+                x11::XFlush(t_dpy);
+            }
+#endif
             if (m_media != nullptr)
             {
                 // Re-attach VLC to the correct output.
@@ -2354,8 +2412,17 @@ void MCVLCPlayer::SetProperty(MCPlatformPlayerProperty p_property,
                 if (m_offscreen)
                     SetupOffscreenCallbacks();
                 else
+                {
                     AttachNativeView();
+                    Synchronize();
+                }
             }
+#if defined(TARGET_PLATFORM_LINUX)
+            else if (!m_offscreen)
+            {
+                Synchronize();
+            }
+#endif
             break;
         }
 

--- a/engine/src/vlc-player.h
+++ b/engine/src/vlc-player.h
@@ -116,7 +116,10 @@ private:
     struct libvlc_media_t        *m_media;
 
     // -- Platform-specific native view / window handle -----------------------
-    void *m_view;       // NSView* on Mac, HWND on Win, (unused) on Linux
+    void *m_view;       // NSView* on Mac, HWND on Win, X11 Window on Linux
+#if defined(TARGET_PLATFORM_LINUX)
+    unsigned long m_colormap;
+#endif
 
     // -- Playback state ------------------------------------------------------
     MCRectangle m_rect;

--- a/ide/Toolset/libraries/revidelibrary.8.livecodescript
+++ b/ide/Toolset/libraries/revidelibrary.8.livecodescript
@@ -5246,7 +5246,10 @@ private on __setPropertyOfObject pObject, pProperty, pValue
    if tProperties["properties"][pProperty]["setter"] is not empty then
       dispatch tProperties["properties"][pProperty]["setter"] with pObject, pProperty, pValue
    else
-      set the pProperty of pObject to pValue
+      try
+         set the pProperty of pObject to pValue
+      catch tError
+      end try
    end if
    
 end __setPropertyOfObject


### PR DESCRIPTION
## Summary

- Enable the VLC-backed platform player on Linux (replacing the legacy MPlayer backend) by switching `FEATURE_MPLAYER` to `FEATURE_PLATFORM_PLAYER` and wiring up the build system
- Embed VLC video inside the application using raw X11 child windows with a 24-bit visual to prevent transparency under compositing WMs, and force `xcb_x11` video output to avoid XV colorkey artifacts
- Propagate widget geometry to the VLC surface on every draw cycle (replacing Mac/Windows native layer), with controller height subtraction so playback controls remain accessible
- Handle edit/preview mode transitions: unmap the X11 window in edit mode (offscreen), re-map with correct geometry on preview mode entry
- Add Linux plugin path probing for future AppImage bundling (`<exe_dir>/vlc-plugins/plugins/`)
- Add `lnx-core-compat.cpp` with Linux implementations of `MCPlatformBreakWait`, `MCPlatformWaitForEvent`, and player callback dispatchers

## Test plan

- [ ] Build on Linux with `libvlc-dev` and `vlc-plugin-video-output` installed
- [ ] Drag a player widget into a stack, set a video file — verify no black rectangle in edit mode
- [ ] Switch to preview mode — verify video renders at the correct widget position with opaque pixels
- [ ] Verify playback controls (play/pause, scrubber) are visible and functional below the video
- [ ] Resize/move the widget in edit mode, switch to preview — verify video tracks new position
- [ ] Verify Mac and Windows builds are unaffected (all Linux changes are `#if defined(TARGET_PLATFORM_LINUX)`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)