### PR TITLE
changed copyright notice

### DIFF
--- a/engine/src/share.cpp
+++ b/engine/src/share.cpp
@@ -1,18 +1,11 @@
-/* Copyright (C) 2003-2015 LiveCode Ltd.
+/* Copyright (C) 2024 HyperXTalk Contributors
 
-This file is part of LiveCode.
+This file is part of HyperXTalk.
 
-LiveCode is free software; you can redistribute it and/or modify it under
+HyperXTalk is free software; you can redistribute it and/or modify it under
 the terms of the GNU General Public License v3 as published by the Free
-Software Foundation.
-
-LiveCode is distributed in the hope that it will be useful, but WITHOUT ANY
-WARRANTY; without even the implied warranty of MERCHANTABILITY or
-FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
-for more details.
-
-You should have received a copy of the GNU General Public License
-along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
+Software Foundation.  */
+*/
 
 // Implementation of the `share` statement:
 //


### PR DESCRIPTION
The copyright notice on share.cpp was the LC notice. I changed it to HyperXTalk.