### PR TITLE
fix: add NSAppleEventsUsageDescription to Info.plist for AppleScript support

### DIFF
--- a/engine/rsrc/HyperXTalk-Info.plist
+++ b/engine/rsrc/HyperXTalk-Info.plist
@@ -63,6 +63,8 @@
 	<string>Revo</string>
 	<key>CFBundleVersion</key>
 	<string>$(BUILD_LONG_VERSION)</string>
+	<key>NSAppleEventsUsageDescription</key>
+	<string>HyperXTalk needs to send Apple events to control other applications via AppleScript.</string>
 	<key>NSContactsUsageDescription</key>
 	<string>This app reads your contacts</string>
 	<key>CSResourcesFileMapped</key>


### PR DESCRIPTION
Add the NSAppleEventsUsageDescription privacy string to HyperXTalk-Info.plist so macOS can display an appropriate explanation when the app requests permission to send Apple events to other applications.

The entitlements file already contained com.apple.security.automation.apple-events and the plist already declared NSAppleScriptEnabled — the usage description was the only missing piece required for App Sandbox / Hardened Runtime compliance.