### PR TITLE
CI: add meson and ninja-build to Linux build deps

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -90,6 +90,7 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y \
             build-essential python3 python3-pip pkg-config \
+            meson ninja-build \
             libssl-dev libcurl4-openssl-dev \
             libgtk-3-dev libglib2.0-dev \
             libpng-dev libjpeg-dev libfreetype6-dev libfontconfig1-dev \


### PR DESCRIPTION
## Summary
- The libcairo 1.18 build script (`prebuilt/scripts/util.inc` → `mesonBinary()`) requires `meson` and `ninja` to configure and build cairo from source
- Without these packages the Linux CI fails with `meson: command not found` during the prebuilt fetch step
- The Mac CI already installs both via `brew install meson ninja`; this adds the equivalent `apt-get` packages for Linux

## Test plan
- [x] Trigger a Linux CI build on this branch and verify it passes the "Compile" step
- [x] Verify the Mac and Windows builds are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)