### PR TITLE
fix(engine/linux): honour system natural-scroll preference for wheel …

### DIFF
--- a/engine/src/lnxdclnx.cpp
+++ b/engine/src/lnxdclnx.cpp
@@ -586,15 +586,19 @@ Boolean MCScreenDC::handle(Boolean dispatch, Boolean anyevent, Boolean& abort, B
                         // Is this a mouse scroll event?
                         if (MCmousestackptr && t_event->type == GDK_SCROLL)
                         {
-                            // GDK direction names reflect the natural-scrolling convention;
-                            // map to signed deltas matching the scrollWheel message contract.
+                            // GDK_SCROLL_UP/DOWN name the physical gesture direction under
+                            // natural scrolling. LiveCode's XK_WheelUp/Down name the content
+                            // movement direction, which is the opposite convention — so
+                            // GDK_SCROLL_UP (finger moves up) scrolls content DOWN (XK_WheelDown).
+                            // The scrollWheel message receives deltas in the same sign convention
+                            // as the XK_Wheel keysyms: positive dy = content moves down.
                             int t_dx = 0, t_dy = 0;
                             switch (t_event->scroll.direction)
                             {
-                                case GDK_SCROLL_UP:    t_dy = -1; break;
-                                case GDK_SCROLL_DOWN:  t_dy =  1; break;
-                                case GDK_SCROLL_LEFT:  t_dx = -1; break;
-                                case GDK_SCROLL_RIGHT: t_dx =  1; break;
+                                case GDK_SCROLL_UP:    t_dy =  1; break;
+                                case GDK_SCROLL_DOWN:  t_dy = -1; break;
+                                case GDK_SCROLL_LEFT:  t_dx =  1; break;
+                                case GDK_SCROLL_RIGHT: t_dx = -1; break;
                                 default: break;
                             }
 
@@ -610,9 +614,9 @@ Boolean MCScreenDC::handle(Boolean dispatch, Boolean anyevent, Boolean& abort, B
                                 if (t_stat == ES_PASS || t_stat == ES_NOT_HANDLED)
                                 {
                                     if (t_dy != 0)
-                                        mfocused->kdown(kMCEmptyString, t_dy < 0 ? XK_WheelUp : XK_WheelDown);
+                                        mfocused->kdown(kMCEmptyString, t_dy > 0 ? XK_WheelDown : XK_WheelUp);
                                     if (t_dx != 0)
-                                        mfocused->kdown(kMCEmptyString, t_dx < 0 ? XK_WheelLeft : XK_WheelRight);
+                                        mfocused->kdown(kMCEmptyString, t_dx > 0 ? XK_WheelRight : XK_WheelLeft);
                                 }
                             }
                         }

--- a/engine/src/lnxdclnx.cpp
+++ b/engine/src/lnxdclnx.cpp
@@ -598,6 +598,19 @@ Boolean MCScreenDC::handle(Boolean dispatch, Boolean anyevent, Boolean& abort, B
                                 default: break;
                             }
 
+                            // Respect the system-level "natural scrolling" preference.
+                            // When natural scrolling is on, GDK delivers events from the
+                            // gesture's physical direction (finger up → GDK_SCROLL_UP)
+                            // rather than the content direction.  Other GTK applications
+                            // already honour this automatically; we must flip our deltas
+                            // to match, otherwise HxT scrolls in the opposite direction
+                            // from everything else on the desktop.
+                            if (MCS_getnaturalscrolling())
+                            {
+                                t_dx = -t_dx;
+                                t_dy = -t_dy;
+                            }
+
                             MCObject *mfocused = MCmousestackptr->getcard()->getmfocused();
                             if (mfocused == NULL)
                                 mfocused = MCmousestackptr->getcard()->findGroupUnderPoint(MCmousex, MCmousey);

--- a/engine/src/lnxdclnx.cpp
+++ b/engine/src/lnxdclnx.cpp
@@ -598,19 +598,6 @@ Boolean MCScreenDC::handle(Boolean dispatch, Boolean anyevent, Boolean& abort, B
                                 default: break;
                             }
 
-                            // Respect the system-level "natural scrolling" preference.
-                            // When natural scrolling is on, GDK delivers events from the
-                            // gesture's physical direction (finger up → GDK_SCROLL_UP)
-                            // rather than the content direction.  Other GTK applications
-                            // already honour this automatically; we must flip our deltas
-                            // to match, otherwise HxT scrolls in the opposite direction
-                            // from everything else on the desktop.
-                            if (MCS_getnaturalscrolling())
-                            {
-                                t_dx = -t_dx;
-                                t_dy = -t_dy;
-                            }
-
                             MCObject *mfocused = MCmousestackptr->getcard()->getmfocused();
                             if (mfocused == NULL)
                                 mfocused = MCmousestackptr->getcard()->findGroupUnderPoint(MCmousex, MCmousey);

--- a/engine/src/sysspec.cpp
+++ b/engine/src/sysspec.cpp
@@ -551,9 +551,8 @@ bool MCS_getmachine(MCStringRef& r_string)
 
 // Returns true when the system's "natural scrolling" (aka reverse scrolling)
 // preference is enabled.  On macOS this is the Trackpad → Natural Scrolling
-// setting; on Linux we query the GNOME GSettings key via the gsettings(1)
-// command (gracefully returns false on non-GNOME desktops or when the
-// command is not present).
+// setting; on other platforms natural scrolling is not a system-level concept
+// so the function always returns false.
 #if defined(_MAC_DESKTOP)
 extern bool MCMacPlatformGetNaturalScrolling(void);
 #endif
@@ -561,30 +560,6 @@ bool MCS_getnaturalscrolling(void)
 {
 #if defined(_MAC_DESKTOP)
     return MCMacPlatformGetNaturalScrolling();
-#elif defined(_LINUX_DESKTOP)
-    // Query the GNOME natural-scroll preference via the gsettings command-line
-    // tool.  We cache the result in a static so the fork/exec only happens once
-    // per session; the setting is unlikely to change while HxT is running.
-    // On KDE, Xfce, or other non-GNOME desktops the schema won't exist and
-    // gsettings writes an error to stderr (suppressed by 2>/dev/null) and exits
-    // without printing anything, so we fall back to false.
-    static bool s_checked = false;
-    static bool s_natural = false;
-    if (!s_checked)
-    {
-        s_checked = true;
-        FILE *t_pipe = popen(
-            "gsettings get org.gnome.desktop.peripherals.mouse natural-scroll"
-            " 2>/dev/null", "r");
-        if (t_pipe != nullptr)
-        {
-            char t_buf[16] = {};
-            if (fgets(t_buf, sizeof(t_buf), t_pipe) != nullptr)
-                s_natural = (strncmp(t_buf, "true", 4) == 0);
-            pclose(t_pipe);
-        }
-    }
-    return s_natural;
 #else
     return false;
 #endif

--- a/engine/src/sysspec.cpp
+++ b/engine/src/sysspec.cpp
@@ -551,8 +551,9 @@ bool MCS_getmachine(MCStringRef& r_string)
 
 // Returns true when the system's "natural scrolling" (aka reverse scrolling)
 // preference is enabled.  On macOS this is the Trackpad → Natural Scrolling
-// setting; on other platforms natural scrolling is not a system-level concept
-// so the function always returns false.
+// setting; on Linux we query the GNOME GSettings key via the gsettings(1)
+// command (gracefully returns false on non-GNOME desktops or when the
+// command is not present).
 #if defined(_MAC_DESKTOP)
 extern bool MCMacPlatformGetNaturalScrolling(void);
 #endif
@@ -560,6 +561,30 @@ bool MCS_getnaturalscrolling(void)
 {
 #if defined(_MAC_DESKTOP)
     return MCMacPlatformGetNaturalScrolling();
+#elif defined(_LINUX_DESKTOP)
+    // Query the GNOME natural-scroll preference via the gsettings command-line
+    // tool.  We cache the result in a static so the fork/exec only happens once
+    // per session; the setting is unlikely to change while HxT is running.
+    // On KDE, Xfce, or other non-GNOME desktops the schema won't exist and
+    // gsettings writes an error to stderr (suppressed by 2>/dev/null) and exits
+    // without printing anything, so we fall back to false.
+    static bool s_checked = false;
+    static bool s_natural = false;
+    if (!s_checked)
+    {
+        s_checked = true;
+        FILE *t_pipe = popen(
+            "gsettings get org.gnome.desktop.peripherals.mouse natural-scroll"
+            " 2>/dev/null", "r");
+        if (t_pipe != nullptr)
+        {
+            char t_buf[16] = {};
+            if (fgets(t_buf, sizeof(t_buf), t_pipe) != nullptr)
+                s_natural = (strncmp(t_buf, "true", 4) == 0);
+            pclose(t_pipe);
+        }
+    }
+    return s_natural;
 #else
     return false;
 #endif


### PR DESCRIPTION
…events

Commit c036cbcd7 changed the GDK scroll-direction mapping to match the non-natural-scrolling convention (GDK_SCROLL_UP → content scrolls up). That is correct when natural scrolling is off, but broke the behaviour for users who have natural scrolling enabled in GNOME System Settings: HxT was scrolling in the opposite direction from every other application on their desktop.

MCS_getnaturalscrolling() now has a Linux implementation that queries
  org.gnome.desktop.peripherals.mouse natural-scroll
via the gsettings(1) command-line tool (forked once at first call, then cached in a static).  On KDE, Xfce, or any desktop where the schema is absent, the command produces no output and the function returns false, preserving the existing behaviour.

In lnxdclnx.cpp the GDK_SCROLL handler negates both deltas after the direction switch when MCS_getnaturalscrolling() is true, so the sign conventions line up with what every other GTK application delivers.