### PR TITLE
Fix/go to definition

### DIFF
--- a/engine/src/module-engine.cpp
+++ b/engine/src/module-engine.cpp
@@ -1129,47 +1129,41 @@ __MCEngineDescribeScriptOfScriptObject_HandlerCallback(void *p_context,
     if (p_include_all)
     {
         MCAutoProperListRef t_global_names;
-        if (!p_handler->getglobalnames_as_properlist(&t_global_names))
+        if (p_handler->getglobalnames_as_properlist(&t_global_names))
         {
-            return false;
+            if (!MCArrayStoreValue(*t_entry,
+                                   false,
+                                   MCNAME("globals"),
+                                   *t_global_names))
+            {
+                return false;
+            }
         }
-        
-        if (!MCArrayStoreValue(*t_entry,
-                               false,
-                               MCNAME("globals"),
-                               *t_global_names))
-        {
-            return false;
-        }
-        
+
         MCAutoProperListRef t_variable_names;
-        if (!p_handler->getvariablenames_as_properlist(&t_variable_names))
+        if (p_handler->getvariablenames_as_properlist(&t_variable_names))
         {
-            return false;
+            if (!MCArrayStoreValue(*t_entry,
+                                   false,
+                                   MCNAME("locals"),
+                                   *t_variable_names))
+            {
+                return false;
+            }
         }
-        
-        if (!MCArrayStoreValue(*t_entry,
-                               false,
-                               MCNAME("locals"),
-                               *t_variable_names))
-        {
-            return false;
-        }
-        
+
         MCAutoProperListRef t_constant_names;
-        if (!p_handler->getconstantnames_as_properlist(&t_constant_names))
+        if (p_handler->getconstantnames_as_properlist(&t_constant_names))
         {
-            return false;
+            if (!MCArrayStoreValue(*t_entry,
+                                   false,
+                                   MCNAME("constants"),
+                                   *t_constant_names))
+            {
+                return false;
+            }
         }
-        
-        if (!MCArrayStoreValue(*t_entry,
-                               false,
-                               MCNAME("constants"),
-                               *t_constant_names))
-        {
-            return false;
-        }
-        
+
     }
     
     if (!MCArrayStoreValue(t_array,

--- a/ide/Toolset/palettes/script editor/behaviors/revsecommoneditorbehavior.livecodescript
+++ b/ide/Toolset/palettes/script editor/behaviors/revsecommoneditorbehavior.livecodescript
@@ -3198,17 +3198,27 @@ command getCaretToken pUseClick
    
    # Don't return tokens in comments. For now we determine if the user is typing
    # in a comment by simple means, using proper tokenization is not yet possible.
-   # This means that multi-line comments will break this.
+   # Multi-line /* */ block comments are not handled.
    local tLine
    if pUseClick then
       put word 2 of the clickLine into tLine
    else
       put word 2 of the selectedLine of getScriptField() into tLine
    end if
-   if token 1 of line tLine of tScript is empty then
+
+   local tLineText
+   put line tLine of tScript into tLineText
+
+   # Blank line
+   if token 1 of tLineText is empty then
       return empty
    end if
-   
+
+   # Line that is entirely a -- comment (handles both -- and --- etc.)
+   if word 1 of tLineText begins with "--" then
+      return empty
+   end if
+
    local tSelectedText
    if pUseClick then
       put the clickText into tSelectedText
@@ -3220,7 +3230,7 @@ command getCaretToken pUseClick
          return tSelectedText
       end if
    end if
-   
+
    # This is expanded to include tokens that the caret was placed immediately before or after,
    # the reason for this is that it allows us to begin searching for tokens while the user is typing.
    local tFrom, tTo
@@ -3231,12 +3241,27 @@ command getCaretToken pUseClick
    end if
    put word 2 of it into tFrom
    put word 4 of it into tTo
-   
+
+   # Check for inline comment: if -- appears anywhere before the click position on
+   # the same line, the click falls inside a comment. Walk back to find the line start.
+   local tLineStart
+   put 1 into tLineStart
+   repeat with i = (tFrom - 1) down to 1
+      if char i of tScript is return then
+         put i + 1 into tLineStart
+         exit repeat
+      end if
+   end repeat
+   if "--" is in (char tLineStart to (tFrom - 1) of tScript) then
+      return empty
+   end if
+
    # We can't perfectly match tokens at the moment, so we just make a reasonable guess with a regular expression
    # to match any char that delimits a token.
    ## AL-2014-01-15: [[ Bug 11094 ]] Added # to the list of script editor token delimiters
-   local tExpression 
-   put "\s|[\%\^\&\*\(\)\-\+\=\]\]\;\,\\@\\\/\<\>\#]" into tExpression
+   ## Added [, ., " as delimiters; removed duplicate ] from character class
+   local tExpression
+   put "\s|[\%\^\&\*\(\)\-\+\=\[\]\.\"\;\,\\@\\\/\<\>\#]" into tExpression
    
    # Try looking backwards first
    local tText, tChar

--- a/ide/Toolset/palettes/script editor/behaviors/revsecommoneditorbehavior.livecodescript
+++ b/ide/Toolset/palettes/script editor/behaviors/revsecommoneditorbehavior.livecodescript
@@ -1,4 +1,4 @@
-script "com.livecode.scripteditor.behavior.editorcommon"
+﻿script "com.livecode.scripteditor.behavior.editorcommon"
 
 -- Autocomplete is always enabled in HyperXTalk.
 -- Defined here so it is always in the message path regardless of
@@ -3261,7 +3261,7 @@ command getCaretToken pUseClick
    ## AL-2014-01-15: [[ Bug 11094 ]] Added # to the list of script editor token delimiters
    ## Added [, ., " as delimiters; removed duplicate ] from character class
    local tExpression
-   put "\s|[\%\^\&\*\(\)\-\+\=\[\]\.\"\;\,\\@\\\/\<\>\#]" into tExpression
+   put "\s|[\%\^\&\*\(\)\-\+\=\[\]\.\" & QUOTE & "\;\,\\@\\\/\<\>\#]" into tExpression
    
    # Try looking backwards first
    local tText, tChar

--- a/ide/Toolset/palettes/script editor/behaviors/revsestackbehavior.livecodescript
+++ b/ide/Toolset/palettes/script editor/behaviors/revsestackbehavior.livecodescript
@@ -1288,12 +1288,12 @@ function seMatchingDefinitions pText, pObject, pHandler
                tDescription[tIndex]["description"]["handlers"][pText]["is_private"] then
             next repeat
          end if
-         
+
          if tDescription[tIndex]["object"] is the long id of pObject then
             put tObjectDescription into tDescription[tIndex]["description"]
          end if
       end if
-      
+
       if tDescription[tIndex]["description"]["handlers"][pText] is an array then
          local tType
          if tDescription[tIndex]["description"]["handlers"][pText]["is_private"] then
@@ -1301,7 +1301,7 @@ function seMatchingDefinitions pText, pObject, pHandler
          else
             put tDescription[tIndex]["description"]["handlers"][pText]["type"] into tType
          end if
-         
+
          put "handler", \
                tType, \
                pText, \
@@ -1309,7 +1309,42 @@ function seMatchingDefinitions pText, pObject, pHandler
                tDescription[tIndex]["object"] & return after tMatches
       end if
    end repeat
-   
+
+   # Fallback: the effective revScriptDescription only reflects the last *applied* script.
+   # If the handler exists in the editor but hasn't been applied yet, the description is
+   # stale and the loop above finds nothing. Scan the current editor script text directly
+   # to catch those cases. We only do this for the object currently being edited (pObject),
+   # since handlers in behaviors or the message path must have been applied to be callable.
+   if tMatches is empty then
+      local tCurrentScript
+      put the text of getScriptField() into tCurrentScript
+      local tLineNum, tLine, tFirstWord, tKeyword, tHandlerName, tScanType
+      repeat with tLineNum = 1 to the number of lines of tCurrentScript
+         put line tLineNum of tCurrentScript into tLine
+         put word 1 of tLine into tFirstWord
+
+         # Handle optional "private" modifier
+         if tFirstWord is "private" then
+            put word 2 of tLine into tKeyword
+            put word 3 of tLine into tHandlerName
+         else
+            put tFirstWord into tKeyword
+            put word 2 of tLine into tHandlerName
+         end if
+
+         if tKeyword is among the items of "on,command,function,getprop,setprop" and \
+               tHandlerName is pText then
+            if tFirstWord is "private" then
+               put "private " & tKeyword into tScanType
+            else
+               put tKeyword into tScanType
+            end if
+            put "handler", tScanType, pText, tLineNum, pObject & return after tMatches
+            exit repeat
+         end if
+      end repeat
+   end if
+
    delete the last char of tMatches
    return tMatches
 end seMatchingDefinitions

--- a/ide/Toolset/palettes/script editor/behaviors/revsestackbehavior.livecodescript
+++ b/ide/Toolset/palettes/script editor/behaviors/revsestackbehavior.livecodescript
@@ -1288,12 +1288,12 @@ function seMatchingDefinitions pText, pObject, pHandler
                tDescription[tIndex]["description"]["handlers"][pText]["is_private"] then
             next repeat
          end if
-
+         
          if tDescription[tIndex]["object"] is the long id of pObject then
             put tObjectDescription into tDescription[tIndex]["description"]
          end if
       end if
-
+      
       if tDescription[tIndex]["description"]["handlers"][pText] is an array then
          local tType
          if tDescription[tIndex]["description"]["handlers"][pText]["is_private"] then
@@ -1301,7 +1301,7 @@ function seMatchingDefinitions pText, pObject, pHandler
          else
             put tDescription[tIndex]["description"]["handlers"][pText]["type"] into tType
          end if
-
+         
          put "handler", \
                tType, \
                pText, \
@@ -1309,42 +1309,7 @@ function seMatchingDefinitions pText, pObject, pHandler
                tDescription[tIndex]["object"] & return after tMatches
       end if
    end repeat
-
-   # Fallback: the effective revScriptDescription only reflects the last *applied* script.
-   # If the handler exists in the editor but hasn't been applied yet, the description is
-   # stale and the loop above finds nothing. Scan the current editor script text directly
-   # to catch those cases. We only do this for the object currently being edited (pObject),
-   # since handlers in behaviors or the message path must have been applied to be callable.
-   if tMatches is empty then
-      local tCurrentScript
-      put the text of getScriptField() into tCurrentScript
-      local tLineNum, tLine, tFirstWord, tKeyword, tHandlerName, tScanType
-      repeat with tLineNum = 1 to the number of lines of tCurrentScript
-         put line tLineNum of tCurrentScript into tLine
-         put word 1 of tLine into tFirstWord
-
-         # Handle optional "private" modifier
-         if tFirstWord is "private" then
-            put word 2 of tLine into tKeyword
-            put word 3 of tLine into tHandlerName
-         else
-            put tFirstWord into tKeyword
-            put word 2 of tLine into tHandlerName
-         end if
-
-         if tKeyword is among the items of "on,command,function,getprop,setprop" and \
-               tHandlerName is pText then
-            if tFirstWord is "private" then
-               put "private " & tKeyword into tScanType
-            else
-               put tKeyword into tScanType
-            end if
-            put "handler", tScanType, pText, tLineNum, pObject & return after tMatches
-            exit repeat
-         end if
-      end repeat
-   end if
-
+   
    delete the last char of tMatches
    return tMatches
 end seMatchingDefinitions

--- a/ide/Toolset/palettes/script editor/behaviors/revsestackbehavior.livecodescript
+++ b/ide/Toolset/palettes/script editor/behaviors/revsestackbehavior.livecodescript
@@ -1263,53 +1263,211 @@ end seFriendlyShortcut
 #   for pText. Empty if none could be found.
 #   Note that for now, only handler definitions are returned.
 function seMatchingDefinitions pText, pObject, pHandler
+   # Handler name lookups must be case-insensitive: LiveCode handler names are
+   # case-insensitive, so a call-site spelling like "myhandler" must match a
+   # definition stored as "myHandler". Also ensures `is` comparisons for object
+   # long IDs are caseless. Save/restore so we don't affect the caller.
+   local tSavedCaseSensitive
+   put the caseSensitive into tSavedCaseSensitive
+   set the caseSensitive to false
+
+   local tMatches
+   local tTopErr
+   try
+
+   # --- Pass 1: pObject's own script (includes private handlers) ---
+   # `the revScriptDescription of pObject` defaults to p_include_all = true,
+   # so private handlers are included. This is the common case: the user
+   # right-clicked on a definition or a call-site in the object being edited.
+   local tOwnDesc
+   local tOwnDescError
+   try
+      put the revScriptDescription of pObject into tOwnDesc
+   catch tOwnDescError
+      put empty into tOwnDesc
+   end try
+   if tOwnDesc is an array and tOwnDesc["handlers"][pText] is an array then
+      local tType
+      if tOwnDesc["handlers"][pText]["is_private"] then
+         put "private" && tOwnDesc["handlers"][pText]["type"] into tType
+      else
+         put tOwnDesc["handlers"][pText]["type"] into tType
+      end if
+      put "handler", \
+            tType, \
+            pText, \
+            tOwnDesc["handlers"][pText]["start_line"], \
+            the long id of pObject & return after tMatches
+   else
+      -- revScriptDescription failed (engine bug: getglobalnames_as_properlist etc.
+      -- return false for some compiled handler, making the whole description nil).
+      -- Fall back to scanning the raw script text for a handler declaration line.
+      -- Locals declared before the loop to avoid re-declaration errors.
+      local tLineNum, tLine, tW1, tW2, tW3
+      put 0 into tLineNum
+      repeat for each line tLine in (the script of pObject)
+         add 1 to tLineNum
+         put word 1 of tLine into tW1
+         put word 2 of tLine into tW2
+         put word 3 of tLine into tW3
+         if tW1 is among the items of "on,function,command,getprop,setprop,before,after" then
+            if tW2 is pText then
+               put "handler", tW1, pText, tLineNum, the long id of pObject & return after tMatches
+               exit repeat
+            end if
+         else if tW1 is "private" then
+            if tW2 is among the items of "on,function,command" then
+               if tW3 is pText then
+                  put "handler", "private" && tW2, pText, tLineNum, \
+                        the long id of pObject & return after tMatches
+                  exit repeat
+               end if
+            end if
+         end if
+      end repeat
+   end if
+
+   # --- Pass 2: rest of the effective message path ---
+   # Only public handlers are reachable from pObject's script, so skip private
+   # handlers from other objects in the path. When pObject is itself a behavior
+   # (tUses[1] exists) use its first user as the anchor for the effective path;
+   # otherwise anchor on pObject itself.
    local tObject
-   
    local tUses
-   put the revBehaviorUses of pObject into tUses
+   local tBehaviorUsesErr
+   try
+      put the revBehaviorUses of pObject into tUses
+   catch tBehaviorUsesErr
+      put empty into tUses
+   end try
    if exists(tUses[1]) then
       put tUses[1] into tObject
    else
       put pObject into tObject
    end if
-   
+
+   local tPObjectLongId
+   put the long id of pObject into tPObjectLongId
+
+   -- The effective revScriptDescription approach fails when the anchor object
+   -- (processed with p_include_all=true) has the engine bug. Multiple objects
+   -- in this stack appear to be affected, so instead walk the owner chain
+   -- manually, checking each object with revScriptDescription and falling back
+   -- to script-text scanning when that also fails.
+
+   -- First try the effective description of tObject (works when tObject != pObject,
+   -- e.g. when pObject is a behavior script used by another object).
    local tDescription
-   put the effective revScriptDescription of tObject into tDescription
-   
-   local tObjectDescription
-   if pObject is not tObject then
-      put the revScriptDescription of pObject into tObjectDescription
-   end if
-   
-   local tMatches
-   repeat with tIndex = 1 to the number of elements of tDescription
-      if pObject is not tObject then
-         if tDescription[tIndex]["object"] is the long id of tObject and \
-               tDescription[tIndex]["description"]["handlers"][pText]["is_private"] then
-            next repeat
+   try
+      put the effective revScriptDescription of tObject into tDescription
+   catch tEffDescErr
+      put empty into tDescription
+   end try
+
+   if tDescription is an array then
+      -- Effective description succeeded; search it for the handler.
+      local tEntryObject, tHandlers, tType2
+      repeat with tIndex = 1 to the number of elements of tDescription
+         put tDescription[tIndex]["object"] into tEntryObject
+
+         if tEntryObject is tPObjectLongId then
+            next repeat   -- already covered in pass 1
          end if
-         
-         if tDescription[tIndex]["object"] is the long id of pObject then
-            put tObjectDescription into tDescription[tIndex]["description"]
+
+         put tDescription[tIndex]["description"]["handlers"] into tHandlers
+
+         if tHandlers[pText] is an array then
+            if tHandlers[pText]["is_private"] then
+               next repeat
+            end if
+
+            put tHandlers[pText]["type"] into tType2
+            put "handler", \
+                  tType2, \
+                  pText, \
+                  tHandlers[pText]["start_line"], \
+                  tEntryObject & return after tMatches
          end if
-      end if
-      
-      if tDescription[tIndex]["description"]["handlers"][pText] is an array then
-         local tType
-         if tDescription[tIndex]["description"]["handlers"][pText]["is_private"] then
-            put "private" && tDescription[tIndex]["description"]["handlers"][pText]["type"] into tType
+      end repeat
+   else
+      -- Effective description failed. Walk the ancestor chain by parsing
+      -- pObject's long id, which yields fully-qualified references at every
+      -- level (e.g. "group id N of card id M of stack id K", then
+      -- "card id M of stack id K", then "stack id K"). This avoids the
+      -- short-form owner references that `the owner of X` returns and that
+      -- the engine cannot resolve as standalone object identifiers.
+      local tCurrentObject, tCurrentDesc, tDescErr2
+      local tType3, tAncLine, tAncLineText, tAW1, tAW2
+      local tCurrentScript, tScriptErr
+      local tAncestorChain, tRemaining, tOfPos
+
+      -- Build the chain: strip the first "type id N of " prefix repeatedly.
+      put empty into tAncestorChain
+      put the long id of pObject into tRemaining
+      put offset(" of ", tRemaining) into tOfPos
+      repeat while tOfPos > 0
+         put char (tOfPos + 4) to -1 of tRemaining into tRemaining
+         put tRemaining & return after tAncestorChain
+         put offset(" of ", tRemaining) into tOfPos
+      end repeat
+      delete the last char of tAncestorChain
+
+      repeat for each line tCurrentObject in tAncestorChain
+         put empty into tCurrentDesc
+         try
+            put the revScriptDescription of tCurrentObject into tCurrentDesc
+         catch tDescErr2
+            put empty into tCurrentDesc
+         end try
+
+         if tCurrentDesc is an array then
+            if tCurrentDesc["handlers"][pText] is an array then
+               if not tCurrentDesc["handlers"][pText]["is_private"] then
+                  put tCurrentDesc["handlers"][pText]["type"] into tType3
+                  put "handler", \
+                        tType3, \
+                        pText, \
+                        tCurrentDesc["handlers"][pText]["start_line"], \
+                        tCurrentObject & return after tMatches
+                  exit repeat
+               end if
+            end if
          else
-            put tDescription[tIndex]["description"]["handlers"][pText]["type"] into tType
+            -- revScriptDescription also failed for this ancestor; scan its script text.
+            put empty into tCurrentScript
+            try
+               put the script of tCurrentObject into tCurrentScript
+            catch tScriptErr
+               put empty into tCurrentScript
+            end try
+            put 0 into tAncLine
+            repeat for each line tAncLineText in tCurrentScript
+               add 1 to tAncLine
+               put word 1 of tAncLineText into tAW1
+               put word 2 of tAncLineText into tAW2
+               if tAW1 is among the items of \
+                     "on,function,command,getprop,setprop,before,after" then
+                  if tAW2 is pText then
+                     put "handler", tAW1, pText, tAncLine, \
+                           tCurrentObject & return after tMatches
+                     exit repeat
+                  end if
+               end if
+            end repeat
          end if
-         
-         put "handler", \
-               tType, \
-               pText, \
-               tDescription[tIndex]["description"]["handlers"][pText]["start_line"], \
-               tDescription[tIndex]["object"] & return after tMatches
-      end if
-   end repeat
-   
+
+         if tMatches is not empty then
+            exit repeat
+         end if
+      end repeat
+   end if
+
+   catch tTopErr
+      put empty into tMatches
+   end try
+
+   set the caseSensitive to tSavedCaseSensitive
+
    delete the last char of tMatches
    return tMatches
 end seMatchingDefinitions


### PR DESCRIPTION
If the engine comes up empty when trying to find a handler, it will now walk the calling path backwards to find the handler.