### PR TITLE
engine: NOOP create toolbar if named toolbar already exists

### DIFF
--- a/engine/src/exec-interface-toolbar.cpp
+++ b/engine/src/exec-interface-toolbar.cpp
@@ -168,9 +168,6 @@ void MCToolbar::GetItemLabel(MCExecContext& ctxt, MCNameRef p_item,
 void MCToolbar::SetItemLabel(MCExecContext& ctxt, MCNameRef p_item,
                              MCStringRef p_label)
 {
-    fprintf(stderr, "[SetItemLabel] called on toolbar %p item=%p\n",
-            (void*)this, (void*)p_item);
-    fflush(stderr);
     MCToolbarItem *t_item = FindItem(p_item);
     if (t_item == nil)
     {

--- a/engine/src/exec-interface.cpp
+++ b/engine/src/exec-interface.cpp
@@ -3199,14 +3199,44 @@ MCControl* MCInterfaceExecCreateControlGetObject(MCExecContext& ctxt, int p_type
 
 void MCInterfaceExecCreateControl(MCExecContext& ctxt, MCStringRef p_new_name, int p_type, MCObject *p_container, bool p_force_invisible)
 {
-    
+
     MCStack *t_current_stack = p_container == nullptr ? MCdefaultstackptr : p_container->getstack();
-    
+
     if (t_current_stack->islocked())
 	{
 		ctxt . LegacyThrow(EE_CREATE_LOCKED);
 		return;
 	}
+
+#ifndef _SERVER
+    // If creating a named toolbar, NOOP if one with that name already exists
+    // in the target stack — prevents wiping icons on a second create call.
+    if (p_type == CT_TOOLBAR && p_new_name != nil)
+    {
+        MCNewAutoNameRef t_toolbar_name;
+        if (MCNameCreate(p_new_name, &t_toolbar_name))
+        {
+            MCControl *t_existing = t_current_stack->getcontrols();
+            if (t_existing != nil)
+            {
+                MCControl *t_ptr = t_existing;
+                do
+                {
+                    if (t_ptr->gettype() == CT_TOOLBAR && t_ptr->hasname(*t_toolbar_name))
+                    {
+                        // Already exists — set 'it' to the existing toolbar and bail out.
+                        MCAutoValueRef t_existing_id;
+                        t_ptr->names(P_LONG_ID, &t_existing_id);
+                        ctxt.SetItToValue(*t_existing_id);
+                        return;
+                    }
+                    t_ptr = (MCControl *)t_ptr->next();
+                }
+                while (t_ptr != t_existing);
+            }
+        }
+    }
+#endif
 
 	MCControl *t_control = MCInterfaceExecCreateControlGetObject(ctxt, p_type, p_container);
 	if (t_control == NULL)

--- a/engine/src/lnx-toolbar.cpp
+++ b/engine/src/lnx-toolbar.cpp
@@ -101,6 +101,12 @@ public:
 
         _applyDisplayMode();
 
+        // Watch for the toolbar being destroyed externally (e.g. when the
+        // parent GtkWindow is torn down before Destroy() is called). The
+        // callback nulls m_toolbar so Destroy() knows not to touch it.
+        g_signal_connect(m_toolbar, "destroy",
+                         G_CALLBACK(_onToolbarWidgetDestroyed), this);
+
         // Pack the toolbar at the top of the parent window's vbox.
         // The engine's Linux window is a GtkWindow with a GtkVBox as the
         // top-level container.
@@ -129,6 +135,10 @@ public:
 #if GTK_MAJOR_VERSION < 4
         if (m_toolbar)
         {
+            // Disconnect our destroy-watcher before explicitly destroying so
+            // the callback doesn't fire redundantly during gtk_widget_destroy.
+            g_signal_handlers_disconnect_by_func(
+                m_toolbar, (gpointer)_onToolbarWidgetDestroyed, this);
             gtk_widget_destroy(m_toolbar);
             m_toolbar = NULL;
         }
@@ -416,6 +426,14 @@ private:
         }
         gtk_toolbar_set_style(GTK_TOOLBAR(m_toolbar), t_style);
 #endif
+    }
+
+    // Called when the GtkToolbar widget is destroyed by GTK (e.g. as a child
+    // of a closing GtkWindow) before Destroy() is called. Nulls m_toolbar so
+    // Destroy() doesn't call gtk_widget_destroy on an already-dead widget.
+    static void _onToolbarWidgetDestroyed(GtkWidget * /*widget*/, gpointer user_data)
+    {
+        static_cast<MCToolbarLinuxBackend *>(user_data)->m_toolbar = NULL;
     }
 
     // Click callback: reads the item name stored on the button widget so the


### PR DESCRIPTION
Calling `create toolbar "mainBar" in this stack` a second time was re-cloning the template toolbar over the existing one, wiping all previously added items and leaving the toolbar in an unrecoverable state.

MCInterfaceExecCreateControl now checks the target stack's control list before cloning: if a CT_TOOLBAR object with the same name already exists, the command returns its long ID in `it` and exits without creating anything. The check is wrapped in #ifndef _SERVER to mirror the existing server-build guard on toolbar support.

Also removed a leftover debug fprintf/fflush from
MCToolbar::SetItemLabel in exec-interface-toolbar.cpp.