### PR TITLE
ci: install meson and ninja-build on Linux runner

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -90,6 +90,7 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y \
             build-essential python3 python3-pip pkg-config \
+            meson ninja-build \
             libssl-dev libcurl4-openssl-dev \
             libgtk-3-dev libglib2.0-dev \
             libpng-dev libjpeg-dev libfreetype6-dev libfontconfig1-dev \


### PR DESCRIPTION
The libcairo prebuilt build script uses meson to generate its build files. meson was missing from the apt-get package list, causing the Linux CI job to fail with "meson: command not found". Added meson and ninja-build to match the Homebrew installs already present in the macOS job.