### PR TITLE
fix(packaging): structure Externals and Extensions properly in Linux AppImage

### DIFF
--- a/packaging/linux/build-appimage.sh
+++ b/packaging/linux/build-appimage.sh
@@ -53,12 +53,34 @@ for subdir in Toolset Resources Documentation Plugins Externals; do
 done
 
 # --- Externals (.so plugins from the build) ---
+# Create the expected directory structure for externals and database drivers.
+mkdir -p "$APPBIN/Externals/Database Drivers"
+
+# Copy libExternal.so, revsecurity.so, and revpdfprinter.so to the main binary directory.
+# They are shared libraries or support libraries rather than standard loadable externals.
+for lib in libExternal.so revsecurity.so revpdfprinter.so; do
+    if [ -f "$OUT_DIR/$lib" ]; then
+        cp "$OUT_DIR/$lib" "$APPBIN/"
+        strip --strip-debug "$APPBIN/$lib" 2>/dev/null || true
+    fi
+done
+
+# Copy standard externals and database drivers to their respective directories inside APPBIN/Externals/
 for so in "$OUT_DIR"/*.so; do
     [ -f "$so" ] || continue
     name="$(basename "$so")"
-    case "$name" in server-*) continue ;; esac
-    cp "$so" "$APPBIN/"
-    strip --strip-debug "$APPBIN/$name" 2>/dev/null || true
+    case "$name" in
+        server-*) continue ;;
+        libExternal.so|revsecurity.so|revpdfprinter.so) continue ;;
+        dbmysql.so|dbodbc.so|dbpostgresql.so|dbsqlite.so)
+            cp "$so" "$APPBIN/Externals/Database Drivers/"
+            strip --strip-debug "$APPBIN/Externals/Database Drivers/$name" 2>/dev/null || true
+            ;;
+        *)
+            cp "$so" "$APPBIN/Externals/"
+            strip --strip-debug "$APPBIN/Externals/$name" 2>/dev/null || true
+            ;;
+    esac
 done
 
 # --- Externals subdirectory from build (CEF etc) ---
@@ -66,10 +88,11 @@ if [ -d "$OUT_DIR/Externals" ]; then
     cp -a "$OUT_DIR/Externals/"* "$APPBIN/Externals/" 2>/dev/null || true
 fi
 
-# --- Packaged extensions ---
+# --- Packaged extensions (widgets and libraries) ---
+# When packaged/installed, the IDE looks in "Extensions" rather than "packaged_extensions"
 if [ -d "$OUT_DIR/packaged_extensions" ]; then
-    mkdir -p "$APPBIN/packaged_extensions"
-    cp -a "$OUT_DIR/packaged_extensions/"* "$APPBIN/packaged_extensions/" 2>/dev/null || true
+    mkdir -p "$APPBIN/Extensions"
+    cp -a "$OUT_DIR/packaged_extensions/"* "$APPBIN/Extensions/" 2>/dev/null || true
 fi
 
 # --- LCI modules ---


### PR DESCRIPTION
Resolves #184

### Description
This PR fixes the packaging structure of the Linux AppImage so that standard loadable externals, database drivers, and extensions (widgets/libraries) are loaded correctly by the engine in a packaged/installed environment.

Specifically:
1. **Externals & Database Drivers**: In installed/packaged mode (when `revEnvironmentIsInstalled()` is true), the engine's external loading logic expects standard loadable externals (like `revxml.so`, `revspeech.so`, `revzip.so`, etc.) under `usr/bin/Externals/` and database drivers (like `dbsqlite.so`, `dbmysql.so`, etc.) under `usr/bin/Externals/Database Drivers/`. Moving these into their correct subdirectories resolves issues where basic XML functions (e.g. `revXMLCreateTree`) fail due to `revxml` not being loaded.
2. **Support/Shared Libraries**: Core support libraries (`libExternal.so`, `revsecurity.so`, `revpdfprinter.so`) remain directly in `usr/bin/` so they can be loaded by the dynamic linker/loader using the binary's `rpath` or `LD_LIBRARY_PATH`.
3. **Extensions**: In packaged/installed mode, the engine searches for packaged extensions/widgets (e.g., SVG Icon widget, TreeView widget) in `usr/bin/Extensions/` instead of `usr/bin/packaged_extensions/`. Restructuring the AppImage build to copy these to `Extensions` fixes the missing expand/collapse `+`/`-` buttons in the Project Browser (which rely on the SVG Icon widget).

### Verification
- Built the AppImage locally and extracted/inspected the `AppDir` contents:
  - Verified `usr/bin/Externals/` contains `revxml.so`, `revspeech.so`, `revzip.so`, `revbrowser.so`.
  - Verified `usr/bin/Externals/Database Drivers/` contains database drivers `dbsqlite.so`, `dbmysql.so`, `dbpostgresql.so`.
  - Verified `usr/bin/Extensions/` contains all widgets/libraries (`com.livecode.widget.treeview`, `com.livecode.library.iconsvg`, etc.).
  - Verified `usr/bin/` contains the flat support libraries `libExternal.so`, `revsecurity.so`, `revpdfprinter.so`.
