### PR TITLE
Fix path in Makefile.common

### DIFF
--- a/Makefile.common
+++ b/Makefile.common
@@ -74,5 +74,5 @@ else
 	bin_dir ?= $(top_srcdir)/$(guess_platform)-bin
 endif
 
-guess_engine := $(if $(filter mac,$(guess_platform)),$(bin_dir)/Standalone-Community.app/Contents/MacOS/Standalone-Community,$(bin_dir)/standalone-community)
-guess_dev_engine := $(if $(filter mac,$(guess_platform)),$(bin_dir)/LiveCode-Community.app/Contents/MacOS/LiveCode-Community,$(bin_dir)/LiveCode-Community)
+guess_engine := $(if $(filter mac,$(guess_platform)),$(bin_dir)/HyperXTalk.app/Contents/MacOS/HyperXTalk,$(bin_dir)/HyperXTalk)
+guess_dev_engine := $(if $(filter mac,$(guess_platform)),$(bin_dir)/HyperXTalk.app/Contents/MacOS/HyperXTalk,$(bin_dir)/HyperXTalk)

--- a/Makefile.common
+++ b/Makefile.common
@@ -68,11 +68,7 @@ guess_engine_flags_script := \
 	fi
 guess_engine_flags := $(shell $(guess_engine_flags_script))
 
-ifeq ($(guess_platform),mac)
-	bin_dir ?= $(top_srcdir)/_build/mac/$(BUILDTYPE)
-else
-	bin_dir ?= $(top_srcdir)/$(guess_platform)-bin
-endif
+bin_dir ?= $(top_srcdir)/$(guess_platform)-bin
 
 guess_engine := $(if $(filter mac,$(guess_platform)),$(bin_dir)/HyperXTalk.app/Contents/MacOS/HyperXTalk,$(bin_dir)/HyperXTalk)
 guess_dev_engine := $(if $(filter mac,$(guess_platform)),$(bin_dir)/HyperXTalk.app/Contents/MacOS/HyperXTalk,$(bin_dir)/HyperXTalk)


### PR DESCRIPTION
Makefile.common attempts to guess the executable path of the engine.  It had not been updated since the original project.  Changed name to HyperXTalk as it should be now.