### PR TITLE
Fix Find & Replace highlight unreadable in Dark Mode

### DIFF
--- a/ide/Toolset/palettes/script editor/behaviors/revseeditorbehavior.livecodescript
+++ b/ide/Toolset/palettes/script editor/behaviors/revseeditorbehavior.livecodescript
@@ -1418,7 +1418,15 @@ end findFinalize
 #   Marks the specified chunk of text as found. This must be done using other means than selecting
 #   the chunk because of interactive search which finds text as the user types.
 command findMarkResult pStart, pEnd, pInteractive
-   set the backgroundColor of char pStart to pEnd of field "Script" of me to sePrefGet("editor,findcolor")
+   -- HXT: Use the dark-mode find colour when in dark mode so that light-coloured
+   -- syntax tokens remain readable against the highlight background.
+   local tFindColor
+   if the systemAppearance is "dark" then
+      put sePrefGet("editor,darkFindColor") into tFindColor
+   else
+      put sePrefGet("editor,findcolor") into tFindColor
+   end if
+   set the backgroundColor of char pStart to pEnd of field "Script" of me to tFindColor
    
    # If using interactive search, we can't select the find text, because doing so will take the 
    # selection away from the search field while the user is probably still typing in it, otherwise this is ok.

--- a/ide/Toolset/palettes/script editor/behaviors/revseutilities.livecodescript
+++ b/ide/Toolset/palettes/script editor/behaviors/revseutilities.livecodescript
@@ -573,6 +573,10 @@ command sePrefGetDefaults
    put 500 into tPrefs["editor,paneupdatedelay"]
    put "false" into tPrefs["editor,findvisible"]
    put "0,200,0" into tPrefs["editor,findcolor"]
+   -- HXT: Separate default for dark mode where bright green makes text hard to read.
+   -- Uses a muted steel blue (à la VS Code dark) so light-coloured syntax tokens
+   -- remain legible against the highlight background.
+   put "38,79,120" into tPrefs["editor,darkFindColor"]
    put empty into tPrefs["editor,font"]
    put 12 into tPrefs["editor,fontsize"]
    put true into tPrefs["editor,autoformat"]


### PR DESCRIPTION
Add editor,darkFindColor preference (default: muted steel blue 38,79,120) as a dark-mode counterpart to editor,findcolor (existing green 0,200,0). findMarkResult now picks between the two based on the systemAppearance, so light-coloured syntax tokens from dark-mode colour schemes remain legible against the find highlight background.

Both keys are user-configurable via sePrefSet; Preferences dialog UI to follow as a separate task.