### PR TITLE
fix/lin-passwordField-caret

### DIFF
--- a/engine/src/exec-interface-field.cpp
+++ b/engine/src/exec-interface-field.cpp
@@ -965,6 +965,13 @@ void MCField::SetPasswordField(MCExecContext& ctxt, bool p_setting)
 {
 	m_password_field = p_setting;
 	Redraw();
+    // Reposition the caret immediately so it appears at the correct x offset
+    // relative to the (now-changed) displayed characters.  Without this the
+    // caret stays at its old pixel position until the next keystroke, which
+    // can place it inside or past the bullet dots on Windows (where the
+    // redraw cycle does not implicitly trigger replacecursor as it does on
+    // other platforms).
+    replacecursor(True, False);
 }
 
 void MCField::GetPasswordToggle(MCExecContext& ctxt, bool& r_setting)

--- a/engine/src/field.cpp
+++ b/engine/src/field.cpp
@@ -1057,6 +1057,11 @@ Boolean MCField::mdown(uint2 which)
                 m_password_field = !m_password_field;
                 message_with_valueref_args(MCM_password_toggle_clicked, m_password_field ? MCSTR("true") : MCSTR("false"));
                 layer_redrawrect(getfrect());
+                // Reposition the caret immediately so it aligns with the new
+                // display (bullets ↔ plain text).  SetPasswordField does the
+                // same via replacecursor, but the toggle icon sets m_password_field
+                // directly, so we must call it here explicitly.
+                replacecursor(True, False);
                 return True;
             }
 

--- a/engine/src/field.h
+++ b/engine/src/field.h
@@ -190,7 +190,13 @@ public:
     using MCMixinObjectHandle<MCField>::GetHandle;
     
 private:
-    
+    // Build a string of U+25CF BLACK CIRCLE characters the same length as
+    // p_para's text.  Used by replacecursor and getcompositionrect to measure
+    // caret/IME positions against the displayed bullet characters rather than
+    // the actual (variably-wide) text.  Returns a retained MCStringRef;
+    // caller must MCValueRelease it.  Never returns nil.
+    MCStringRef _makeBulletString(MCParagraph *p_para) const;
+
 	friend class MCHcfield;
 	MCCdata *fdata;
 	MCCdata *oldfdata;

--- a/engine/src/fieldf.cpp
+++ b/engine/src/fieldf.cpp
@@ -649,6 +649,26 @@ void MCField::drawcursor(MCContext *p_context, const MCRectangle &dirty)
 	}
 }
 
+MCStringRef MCField::_makeBulletString(MCParagraph *p_para) const
+{
+    MCStringRef t_result = nil;
+    uint32_t t_len = p_para->gettextlength();
+    if (t_len > 0)
+    {
+        unichar_t *t_chars;
+        if (MCMemoryAllocate(t_len * sizeof(unichar_t), t_chars))
+        {
+            for (uint32_t i = 0; i < t_len; i++)
+                t_chars[i] = 0x25CF; // U+25CF BLACK CIRCLE ●
+            /* UNCHECKED */ MCStringCreateWithChars(t_chars, t_len, t_result);
+            MCMemoryDeallocate(t_chars);
+        }
+    }
+    if (t_result == nil)
+        t_result = MCValueRetain(kMCEmptyString);
+    return t_result;
+}
+
 void MCField::replacecursor(Boolean force, Boolean goal)
 {
 	if (!opened)
@@ -664,20 +684,7 @@ void MCField::replacecursor(Boolean force, Boolean goal)
     MCStringRef t_cursor_bullet = nil;
     if (m_password_field && focusedparagraph != nil)
     {
-        uint32_t t_len = focusedparagraph->gettextlength();
-        if (t_len > 0)
-        {
-            unichar_t *t_chars;
-            if (MCMemoryAllocate(t_len * sizeof(unichar_t), t_chars))
-            {
-                for (uint32_t i = 0; i < t_len; i++)
-                    t_chars[i] = 0x25CF; // U+25CF BLACK CIRCLE ●
-                /* UNCHECKED */ MCStringCreateWithChars(t_chars, t_len, t_cursor_bullet);
-                MCMemoryDeallocate(t_chars);
-            }
-        }
-        if (t_cursor_bullet == nil)
-            t_cursor_bullet = MCValueRetain(kMCEmptyString);
+        t_cursor_bullet = _makeBulletString(focusedparagraph);
         focusedparagraph->SetPasswordDisplay(t_cursor_bullet);
     }
 
@@ -2760,16 +2767,45 @@ Boolean MCField::getcompositionrect(MCRectangle &r, findex_t offset)
 		si = composeoffset+offset;
 		ei = composeoffset+composelength;
 		pgptr = indextoparagraph(paragraphs,si,ei);
+
+        // In password mode measure against the bullet string so the IME
+        // candidate window appears at the correct x position (matching the
+        // displayed dots) rather than the actual character positions.
+        MCStringRef t_bullet = nil;
+        if (m_password_field)
+            t_bullet = _makeBulletString(pgptr);
+        if (t_bullet != nil)
+            pgptr->SetPasswordDisplay(t_bullet);
+
 		// MW-2012-01-25: [[ ParaStyles ]] Fetch the cursor rect ignoring any space.
 		r = pgptr->getcursorrect(si, fixedheight, false);
+
+        if (t_bullet != nil)
+        {
+            pgptr->ClearPasswordDisplay();
+            MCValueRelease(t_bullet);
+        }
 	}
 	else
 	{
 		if (!focusedparagraph)
 			return False;
 		pgptr = focusedparagraph;
+
+        MCStringRef t_bullet = nil;
+        if (m_password_field)
+            t_bullet = _makeBulletString(pgptr);
+        if (t_bullet != nil)
+            pgptr->SetPasswordDisplay(t_bullet);
+
 		// MW-2012-01-25: [[ ParaStyles ]] Fetch the cursor rect ignoring any space.
 		r = pgptr->getcursorrect(-1, fixedheight, false);
+
+        if (t_bullet != nil)
+        {
+            pgptr->ClearPasswordDisplay();
+            MCValueRelease(t_bullet);
+        }
 	}
 
 	// MW-2012-01-25: [[ FieldMetrics ]] Conver the rect to card coords.

--- a/engine/src/fieldf.cpp
+++ b/engine/src/fieldf.cpp
@@ -655,15 +655,46 @@ void MCField::replacecursor(Boolean force, Boolean goal)
 		return;
 
 	MCRectangle drectp, drects;
+
+    // If password mode is active, set up the bullet display on the focused paragraph
+    // before calling getcursorrect so that caret x positions are measured against
+    // the bullet string (matching the drawn display) rather than the actual text.
+    // Without this, the caret drifts because real characters are typically wider
+    // than the bullet character used for masking.
+    MCStringRef t_cursor_bullet = nil;
+    if (m_password_field && focusedparagraph != nil)
+    {
+        uint32_t t_len = focusedparagraph->gettextlength();
+        if (t_len > 0)
+        {
+            unichar_t *t_chars;
+            if (MCMemoryAllocate(t_len * sizeof(unichar_t), t_chars))
+            {
+                for (uint32_t i = 0; i < t_len; i++)
+                    t_chars[i] = 0x25CF; // U+25CF BLACK CIRCLE ●
+                /* UNCHECKED */ MCStringCreateWithChars(t_chars, t_len, t_cursor_bullet);
+                MCMemoryDeallocate(t_chars);
+            }
+        }
+        if (t_cursor_bullet == nil)
+            t_cursor_bullet = MCValueRetain(kMCEmptyString);
+        focusedparagraph->SetPasswordDisplay(t_cursor_bullet);
+    }
+
     // AL-2014-03-21: [[ Bug 11963 ]] If the field has list behavior, don't split
     //  the cursor rect.
     if (flags & F_LIST_BEHAVIOR)
 	{
 		drectp = focusedparagraph->getcursorrect(-1, fixedheight, true);
+        if (t_cursor_bullet != nil)
+        {
+            focusedparagraph->ClearPasswordDisplay();
+            MCValueRelease(t_cursor_bullet);
+        }
 		positioncursor(force, goal, drectp, focusedy, true);
 		return;
 	}
-    
+
 	if (composing && composelength)
 	{
 		findex_t compsi, compei;
@@ -682,6 +713,13 @@ void MCField::replacecursor(Boolean force, Boolean goal)
 		drectp = focusedparagraph->getcursorrect(-1, fixedheight, false, kMCParagraphCursorTypePrimary);
         drects = focusedparagraph->getcursorrect(-1, fixedheight, false, kMCParagraphCursorTypeSecondary);
 	}
+
+    if (t_cursor_bullet != nil)
+    {
+        focusedparagraph->ClearPasswordDisplay();
+        MCValueRelease(t_cursor_bullet);
+    }
+
 	positioncursor(force, goal, drects, focusedy, false);
     positioncursor(force, goal, drectp, focusedy, true);
 }
@@ -1158,7 +1196,7 @@ void MCField::drawrect(MCDC *dc, const MCRectangle &dirty)
 						if (MCMemoryAllocate(t_len * sizeof(unichar_t), t_chars))
 						{
 							for (uint32_t i = 0; i < t_len; i++)
-								t_chars[i] = 0x2022; // U+2022 BULLET •
+								t_chars[i] = 0x25CF; // U+25CF BLACK CIRCLE ●
 							/* UNCHECKED */ MCStringCreateWithChars(t_chars, t_len, t_bullet_str);
 							MCMemoryDeallocate(t_chars);
 						}

--- a/engine/src/fields.cpp
+++ b/engine/src/fields.cpp
@@ -1958,16 +1958,31 @@ MCRectangle MCField::firstRectForCharacterRange(int32_t& si, int32_t& ei)
 	si = si + t_si;
 	ei = si + t_ei;
 	
+	// In password mode, measure against the bullet display so the rect returned
+	// to macOS (via firstRectForCharacterRange: / MCPlatformHandleTextInputQueryTextRect)
+	// reflects the displayed dot positions rather than the actual character positions.
+	MCStringRef t_bullet = nil;
+	if (m_password_field)
+		t_bullet = _makeBulletString(sptr);
+	if (t_bullet != nil)
+		sptr->SetPasswordDisplay(t_bullet);
+
 	// Get the x, y of the initial index.
 	coord_t x, y;
 	sptr->indextoloc(t_si, fixedheight, x, y);
-	
+
 	// Get the offset for computing card coords.
 	int4 yoffset = getcontenty() + paragraphtoy(sptr);
-	
+
 	// Get the extent of the range.
 	coord_t minx, maxx;
 	sptr -> getxextents(t_si, t_ei, minx, maxx);
+
+	if (t_bullet != nil)
+	{
+		sptr->ClearPasswordDisplay();
+		MCValueRelease(t_bullet);
+	}
 	
 	MCRectangle t_rect;
 	t_rect . x = minx + getcontentx();


### PR DESCRIPTION
use a larger dot and move the caret when toggling the password