### PR TITLE
[lin] engine: add Linux toolbar backend with GDK/Cairo/Pango

### DIFF
--- a/engine/src/exec-interface.cpp
+++ b/engine/src/exec-interface.cpp
@@ -3260,14 +3260,38 @@ MCControl* MCInterfaceExecCreateControlGetObject(MCExecContext& ctxt, int p_type
 
 void MCInterfaceExecCreateControl(MCExecContext& ctxt, MCStringRef p_new_name, int p_type, MCObject *p_container, bool p_force_invisible)
 {
-    
+
     MCStack *t_current_stack = p_container == nullptr ? MCdefaultstackptr : p_container->getstack();
-    
+
     if (t_current_stack->islocked())
 	{
 		ctxt . LegacyThrow(EE_CREATE_LOCKED);
 		return;
 	}
+
+    // A stack supports at most one toolbar.  If one already exists, behave
+    // like macOS and Windows: treat createToolbar as a no-op and set 'it' to
+    // the existing toolbar's long ID so the caller can still reference it.
+    if (p_type == CT_TOOLBAR)
+    {
+        MCControl *t_cptr = t_current_stack->getcontrols();
+        if (t_cptr != nullptr)
+        {
+            MCControl *t_it = t_cptr;
+            do
+            {
+                if (t_it->gettype() == CT_TOOLBAR)
+                {
+                    MCAutoValueRef t_id;
+                    t_it->names(P_LONG_ID, &t_id);
+                    ctxt.SetItToValue(*t_id);
+                    return;
+                }
+                t_it = t_it->next();
+            }
+            while (t_it != t_cptr);
+        }
+    }
 
 	MCControl *t_control = MCInterfaceExecCreateControlGetObject(ctxt, p_type, p_container);
 	if (t_control == NULL)

--- a/engine/src/linux.stubs
+++ b/engine/src/linux.stubs
@@ -72,6 +72,9 @@ pangoft2 libpangoft2-1.0.so.0
 
 pangocairo libpangocairo-1.0.so.0
 	pango_cairo_font_map_get_default: () -> (pointer)
+	pango_cairo_create_layout: (pointer) -> (pointer)
+	pango_cairo_update_layout: (pointer, pointer) -> ()
+	pango_cairo_show_layout: (pointer, pointer) -> ()
 
 pango libpango-1.0.so.0
 	pango_context_new: () -> (pointer)
@@ -91,6 +94,7 @@ pango libpango-1.0.so.0
 	pango_layout_set_font_description: (pointer, pointer) -> ()
 	pango_layout_get_extents: (pointer, pointer, pointer) -> ()
 	pango_layout_get_pixel_extents: (pointer, pointer, pointer) -> ()
+	pango_layout_get_pixel_size: (pointer, pointer, pointer) -> ()
 	pango_layout_get_iter: (pointer) -> (pointer)
 	pango_layout_iter_free: (pointer) -> ()
 	pango_layout_iter_get_run: (pointer) -> (pointer)
@@ -301,6 +305,7 @@ gdk libgdk-x11-2.0.so.0
 	gdk_keyval_to_unicode: (integer) -> (integer)
 	gdk_rgb_find_color: (pointer, pointer) -> ()
 	gdk_drawable_get_colormap: (pointer) -> (pointer)
+	gdk_drawable_get_visual: (pointer) -> (pointer)
 	gdk_window_set_background: (pointer, pointer, integer) -> ()
 	gdk_notify_startup_complete: () -> ()
 	gdk_window_ensure_native: (pointer) -> (integer)
@@ -335,6 +340,8 @@ gdk libgdk-x11-2.0.so.0
 	gdk_cairo_set_source_window: (pointer, pointer, double, double) -> ()
 	gdk_window_input_shape_combine_region: (pointer, pointer, integer, integer) -> ()
 	gdk_window_get_frame_extents: (pointer, pointer) -> ()
+	gdk_window_add_filter: (pointer, pointer, pointer) -> ()
+	gdk_window_remove_filter: (pointer, pointer, pointer) -> ()
 
 gdk_pixbuf libgdk_pixbuf-2.0.so.0
 	gdk_pixbuf_get_pixels: (pointer) -> (pointer)
@@ -353,11 +360,29 @@ gdk_pixbuf libgdk_pixbuf-2.0.so.0
 cairo libcairo.so.2
 	cairo_set_operator: (pointer, integer) -> ()
 	cairo_destroy: (pointer) -> ()
-	cairo_set_source_rgba: (pointer, integer, integer, integer) -> ()
+	cairo_set_source_rgba: (pointer, double, double, double, double) -> ()
 	cairo_clip: (pointer) -> ()
 	cairo_paint: (pointer) -> ()
-	cairo_rectangle: (pointer, integer, integer, integer, integer) -> ()
+	cairo_rectangle: (pointer, double, double, double, double) -> ()
 	cairo_fill: (pointer) -> ()
+	cairo_pattern_create_linear: (double, double, double, double) -> (pointer)
+	cairo_pattern_add_color_stop_rgb: (pointer, double, double, double, double) -> ()
+	cairo_set_source: (pointer, pointer) -> ()
+	cairo_pattern_destroy: (pointer) -> ()
+	cairo_save: (pointer) -> ()
+	cairo_restore: (pointer) -> ()
+	cairo_translate: (pointer, double, double) -> ()
+	cairo_scale: (pointer, double, double) -> ()
+	cairo_paint_with_alpha: (pointer, double) -> ()
+	cairo_set_source_rgb: (pointer, double, double, double) -> ()
+	cairo_set_line_width: (pointer, double) -> ()
+	cairo_move_to: (pointer, double, double) -> ()
+	cairo_line_to: (pointer, double, double) -> ()
+	cairo_stroke: (pointer) -> ()
+	cairo_select_font_face: (pointer, pointer, integer, integer) -> ()
+	cairo_set_font_size: (pointer, double) -> ()
+	cairo_text_extents: (pointer, pointer, pointer) -> ()
+	cairo_show_text: (pointer, pointer) -> ()
 
 gtk libgtk-x11-2.0.so.0
 	#@ gtk_major_version

--- a/engine/src/lnx-toolbar.cpp
+++ b/engine/src/lnx-toolbar.cpp
@@ -190,6 +190,18 @@ public:
         if (!m_window)
             return;
 
+        // Hold extra GObject references on both windows.  When the engine
+        // calls gdk_window_destroy(parent), GDK internally recurses into all
+        // GDK-registered children and calls g_object_unref on each one.
+        // Without these extra refs that drops the child's GdkWindowObject
+        // refcount to zero, freeing the memory.  Then when MCToolbar::close()
+        // → Destroy() runs (AFTER stack destroywindow()), m_window is a
+        // dangling pointer and any GDK call on it crashes.  By holding an
+        // extra ref here we guarantee the GdkWindowObjects stay allocated
+        // until we explicitly release them at the bottom of Destroy().
+        g_object_ref(m_window);
+        g_object_ref(m_parent);
+
         // Request the events we need for drawing and interaction.
         gdk_window_set_events(m_window,
             GdkEventMask(GDK_EXPOSURE_MASK      |
@@ -222,19 +234,29 @@ public:
     {
 #if GTK_MAJOR_VERSION < 4
         for (int i = 0; i < m_item_count; i++)
-            m_items[i].~LnxItemData();
+            _clearItem(i);
         m_item_count = 0;
         m_hover_idx  = -1;
 
         if (m_window)
         {
             gdk_window_remove_filter(m_window, _filterFunc, this);
+            // gdk_window_destroy is a no-op if GDK has already marked this
+            // window as destroyed (e.g. because the parent was destroyed first
+            // and GDK recursively destroyed all children).
+            // The tail-call g_object_unref inside gdk_window_destroy ALWAYS
+            // runs though: it drops the GDK/engine ref (refcount 2→1).
             gdk_window_destroy(m_window);
+            // Release our extra ref (taken in Create) — refcount 1→0, frees
+            // the GdkWindowObject.  Safe to call because our extra ref kept
+            // the object allocated through gdk_window_destroy above.
+            g_object_unref(m_window);
             m_window = NULL;
         }
         if (m_parent)
         {
             gdk_window_remove_filter(m_parent, _parentResizeFunc, this);
+            g_object_unref(m_parent);
             m_parent = NULL;
         }
 #endif
@@ -250,8 +272,7 @@ public:
 
         int t_idx = m_item_count;
         LnxItemData *it = &m_items[t_idx];
-        new (it) LnxItemData();
-
+        // slot is already default-constructed (part of the member array)
         it->name.Reset(p_item->GetName());
         it->style   = p_item->GetStyle();
         it->enabled = p_item->GetEnabled();
@@ -289,25 +310,20 @@ public:
         if (t_found < 0)
             return;
 
-        m_items[t_found].~LnxItemData();
+        _clearItem(t_found);
 
-        // Shift remaining items down, transferring ownership of icon/label.
+        // Shift remaining items down.
         for (int j = t_found; j < m_item_count - 1; j++)
         {
-            new (&m_items[j]) LnxItemData();
+            // slot j is already clear; transfer slot j+1 into it
             m_items[j].name.Reset(*m_items[j + 1].name);
             m_items[j].style   = m_items[j + 1].style;
             m_items[j].enabled = m_items[j + 1].enabled;
-            // Transfer GdkPixbuf / label ownership without ref-counting.
-            m_items[j].icon  = m_items[j + 1].icon;
-            m_items[j].label = m_items[j + 1].label;
-            m_items[j + 1].icon  = NULL;  // neutralise before destructor
-            m_items[j + 1].label = NULL;
-            m_items[j + 1].~LnxItemData();
+            m_items[j].icon    = m_items[j + 1].icon;    m_items[j + 1].icon  = NULL;
+            m_items[j].label   = m_items[j + 1].label;   m_items[j + 1].label = NULL;
+            _clearItem(j + 1);
         }
 
-        // Re-initialise the now-empty last slot.
-        new (&m_items[m_item_count - 1]) LnxItemData();
         m_item_count--;
 
         if (m_hover_idx >= m_item_count)
@@ -356,7 +372,7 @@ public:
     {
 #if GTK_MAJOR_VERSION < 4
         for (int i = 0; i < m_item_count; i++)
-            m_items[i].~LnxItemData();
+            _clearItem(i);
         m_item_count = 0;
         m_hover_idx  = -1;
         if (m_window)
@@ -402,6 +418,18 @@ private:
     int                  m_parent_width;
     int                  m_hover_idx;    // -1 = none
     LnxItemData          m_items[256];
+
+    // ── helpers ──────────────────────────────────────────────────────────────
+
+    // Release and null all resources owned by slot i without ending the
+    // object's lifetime.  After this call the slot is safe to overwrite or
+    // to have its implicit destructor run (which will then be a no-op).
+    void _clearItem(int i)
+    {
+        m_items[i].name.Reset();  // MCAutoValueRefBase::Reset(nil): releases and zeroes m_value
+        if (m_items[i].icon)  { g_object_unref(m_items[i].icon);  m_items[i].icon  = NULL; }
+        if (m_items[i].label) { free(m_items[i].label);            m_items[i].label = NULL; }
+    }
 
     // ── layout ───────────────────────────────────────────────────────────────
 

--- a/engine/src/lnx-toolbar.cpp
+++ b/engine/src/lnx-toolbar.cpp
@@ -1,60 +1,65 @@
 //
-// Linux GTK toolbar backend for MCToolbar.
-// Uses GtkToolbar (GTK 3). On GTK 4 this class is a no-op stub —
-// a GtkBox+GtkButton implementation can replace it later.
+// Linux toolbar backend for MCToolbar.
+//
+// Uses a child GdkWindow drawn entirely with Cairo/GdkPixbuf.  This is
+// architecturally consistent with the rest of the engine, which uses raw
+// GdkWindows throughout rather than wrapping everything in GtkWidgets.
+//
+// Design
+// ------
+//  • Create() creates a GdkWindow child of the stack's window, positioned at
+//    y = getToolbarTopY() and sized width × kToolbarHeight.
+//  • A per-window Xlib event filter (_filterFunc) handles Expose (draws
+//    synchronously with Cairo) and ButtonPress (hit-tests items and fires
+//    itemClicked).  Motion/Leave events drive the hover highlight.
+//  • A second filter on the PARENT window (_parentResizeFunc) watches for
+//    ConfigureNotify so we can resize the toolbar when the stack window resizes.
+//  • No changes to lnxstack.cpp or lnxdclnx.cpp are required.
+//
+// Content offset
+// --------------
+//  The toolbar child window clips the parent window's drawing, so the top
+//  kToolbarHeight pixels of the stack canvas are visually covered by the
+//  toolbar.  Scripts should position card content below that offset.
+//  (A future enhancement could expose getToolbarHeight() so the engine can
+//   adjust the card viewport automatically.)
+//
+// GTK 4 note
+// ----------
+//  GdkWindow was replaced by GdkSurface in GTK 4; the whole file is guarded
+//  with GTK_MAJOR_VERSION < 4.  A GtkBox+GtkButton replacement can be
+//  written later for GTK 4 when needed.
 //
 
 #ifdef TARGET_PLATFORM_LINUX
 
-#include <gtk/gtk.h>
+// lnxprefix.h must come first: it includes GDK headers and wraps
+// <gdk/gdkx.h> (and its X11 transitive includes) inside "namespace x11 {}"
+// to prevent X11 macro/type clashes with the engine's own sysdefs.h.
+// X11 struct types (XEvent, etc.) are therefore in the x11:: namespace;
+// X11 macros (Expose, ButtonPress, …) are still global because #define
+// ignores C++ namespaces.
+#include "lnxprefix.h"
 
-#include "prefix.h"
+#include <gtk/gtk.h>        // GTK/GDK/Cairo types and helpers
 #include "toolbar.h"
 
-////////////////////////////////////////////////////////////////////////////////
+// ─────────────────────────────────────────────────────────────────────────────
+// Tuneable constants
+// ─────────────────────────────────────────────────────────────────────────────
 
-struct LnxToolbarItemData
-{
-    MCNewAutoNameRef   name;
-    GtkToolItem    *widget;   // nil for separator/space items
-};
+static const int kToolbarHeight   = 48;   // fixed pixel height of the bar
+static const int kIconSize        = 24;   // max icon dimension (square)
+static const int kItemMinWidth    = 64;   // minimum width of a button item
+static const int kSeparatorWidth  = 10;   // width of a separator item
+static const int kSpaceWidth      = 16;   // width of a fixed-space item
+static const int kFlexSpaceMin    = 4;    // minimum width of a flex-space item
+static const int kLabelFontSize   = 10;   // points
+static const int kIconLabelGap    = 2;    // pixels between icon bottom and label top
 
-////////////////////////////////////////////////////////////////////////////////
-// GTK image loader: decode PNG bytes via GdkPixbufLoader
-
-static GdkPixbuf *_pixbufFromPNGData(const void *p_bytes, uindex_t p_length)
-{
-    if (!p_bytes || p_length == 0)
-        return NULL;
-
-    GdkPixbufLoader *t_loader = gdk_pixbuf_loader_new_with_type("png", NULL);
-    if (!t_loader)
-        return NULL;
-
-    GError *t_err = NULL;
-    if (!gdk_pixbuf_loader_write(t_loader,
-                                 (const guchar *)p_bytes,
-                                 (gsize)p_length,
-                                 &t_err))
-    {
-        if (t_err) g_error_free(t_err);
-        gdk_pixbuf_loader_close(t_loader, NULL);
-        g_object_unref(t_loader);
-        return NULL;
-    }
-    gdk_pixbuf_loader_close(t_loader, NULL);
-
-    GdkPixbuf *t_pixbuf = gdk_pixbuf_loader_get_pixbuf(t_loader);
-    if (t_pixbuf)
-        g_object_ref(t_pixbuf); // caller owns this ref
-    g_object_unref(t_loader);
-    return t_pixbuf;
-}
-
-////////////////////////////////////////////////////////////////////////////////
-// UTF-8 RAII helper: wraps MCStringConvertToUTF8String / MCMemoryDelete.
-// GTK uses UTF-8 exclusively; this ensures correct output regardless of the
-// system locale setting.
+// ─────────────────────────────────────────────────────────────────────────────
+// UTF-8 RAII helper
+// ─────────────────────────────────────────────────────────────────────────────
 
 struct MCAutoUTF8String
 {
@@ -74,195 +79,242 @@ struct MCAutoUTF8String
     const char *operator*() const { return m_str ? m_str : ""; }
 };
 
-////////////////////////////////////////////////////////////////////////////////
+// ─────────────────────────────────────────────────────────────────────────────
+// PNG → GdkPixbuf
+// ─────────────────────────────────────────────────────────────────────────────
+
+static GdkPixbuf *_pixbufFromPNGData(const void *p_bytes, uindex_t p_length)
+{
+    if (!p_bytes || p_length == 0)
+        return NULL;
+
+    GdkPixbufLoader *t_loader = gdk_pixbuf_loader_new_with_type("png", NULL);
+    if (!t_loader)
+        return NULL;
+
+    GError *t_err = NULL;
+    if (!gdk_pixbuf_loader_write(t_loader,
+                                 (const guchar *)p_bytes, (gsize)p_length,
+                                 &t_err))
+    {
+        if (t_err) g_error_free(t_err);
+        gdk_pixbuf_loader_close(t_loader, NULL);
+        g_object_unref(t_loader);
+        return NULL;
+    }
+    gdk_pixbuf_loader_close(t_loader, NULL);
+
+    GdkPixbuf *t_pixbuf = gdk_pixbuf_loader_get_pixbuf(t_loader);
+    if (t_pixbuf)
+        g_object_ref(t_pixbuf);
+    g_object_unref(t_loader);
+    return t_pixbuf;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Per-item storage (in-place constructed inside a fixed array)
+// ─────────────────────────────────────────────────────────────────────────────
+
+struct LnxItemData
+{
+    MCNewAutoNameRef   name;
+    MCToolbarItemStyle style;
+    bool               enabled;
+    GdkPixbuf         *icon;    // caller-owned ref; NULL if absent
+    char              *label;   // heap-allocated UTF-8; NULL if absent
+    int                x;       // assigned by _relayout()
+    int                width;   // assigned by _relayout()
+
+    LnxItemData()
+        : style(kMCToolbarItemStyleButton), enabled(true),
+          icon(NULL), label(NULL), x(0), width(0) {}
+
+    ~LnxItemData()
+    {
+        if (icon)  { g_object_unref(icon);  icon  = NULL; }
+        if (label) { free(label);            label = NULL; }
+    }
+};
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Backend class
+// ─────────────────────────────────────────────────────────────────────────────
 
 class MCToolbarLinuxBackend : public MCToolbarBackend
 {
 public:
     MCToolbarLinuxBackend(MCToolbar *p_owner)
-        : m_owner(p_owner), m_toolbar(NULL), m_parent(NULL),
+        : m_owner(p_owner), m_window(NULL), m_parent(NULL),
           m_item_count(0), m_visible(true),
-          m_display_mode(kMCToolbarDisplayModeDefault)
-    {
-    }
+          m_display_mode(kMCToolbarDisplayModeDefault),
+          m_top_y(0), m_parent_width(0), m_hover_idx(-1)
+    {}
 
-    ~MCToolbarLinuxBackend() override {}
+    ~MCToolbarLinuxBackend() override { Destroy(); }
+
+    // ── lifecycle ────────────────────────────────────────────────────────────
 
     void Create(void *p_window_handle) override
     {
 #if GTK_MAJOR_VERSION < 4
-        m_parent = (GtkWidget *)p_window_handle;
-        if (!m_parent)
+        // Idempotent: clean up any previous window so that calling Create()
+        // a second time (e.g. a second 'createToolbar' without a prior close)
+        // starts from a known-good state instead of leaking the old window and
+        // double-registering event filters.
+        Destroy();
+
+        if (!p_window_handle)
             return;
 
-        m_toolbar = gtk_toolbar_new();
-        if (!m_toolbar)
+        m_parent = (GdkWindow *)p_window_handle;
+        m_top_y  = m_owner->getToolbarTopY();
+        m_parent_width = gdk_window_get_width(m_parent);
+
+        GdkWindowAttr t_attr;
+        memset(&t_attr, 0, sizeof(t_attr));
+        t_attr.window_type = GDK_WINDOW_CHILD;
+        t_attr.wclass      = GDK_INPUT_OUTPUT;
+        t_attr.x           = 0;
+        t_attr.y           = m_top_y;
+        t_attr.width       = m_parent_width > 0 ? m_parent_width : 1;
+        t_attr.height      = kToolbarHeight;
+        // Match the parent's visual and colormap exactly.  The engine may use
+        // an RGBA composite visual; if the child window uses a different visual
+        // the compositor treats it as transparent.
+        t_attr.visual   = gdk_drawable_get_visual((GdkDrawable *)m_parent);
+        t_attr.colormap = gdk_drawable_get_colormap((GdkDrawable *)m_parent);
+
+        m_window = gdk_window_new(m_parent, &t_attr,
+                                  GDK_WA_X | GDK_WA_Y |
+                                  GDK_WA_VISUAL | GDK_WA_COLORMAP);
+        if (!m_window)
             return;
 
-        _applyDisplayMode();
+        // Request the events we need for drawing and interaction.
+        gdk_window_set_events(m_window,
+            GdkEventMask(GDK_EXPOSURE_MASK      |
+                         GDK_BUTTON_PRESS_MASK   |
+                         GDK_POINTER_MOTION_MASK |
+                         GDK_ENTER_NOTIFY_MASK   |
+                         GDK_LEAVE_NOTIFY_MASK));
 
-        // Pack the toolbar at the top of the parent window's vbox.
-        // The engine's Linux window is a GtkWindow with a GtkVBox as the
-        // top-level container.
-        GtkWidget *t_child = gtk_bin_get_child(GTK_BIN(m_parent));
-        if (t_child && GTK_IS_BOX(t_child))
-        {
-            gtk_box_pack_start(GTK_BOX(t_child), m_toolbar,
-                               FALSE, FALSE, 0);
-            gtk_box_reorder_child(GTK_BOX(t_child), m_toolbar, 0);
-        }
-        else
-        {
-            // Fallback: add directly to window
-            gtk_container_add(GTK_CONTAINER(m_parent), m_toolbar);
-        }
+        // Per-window Xlib filters.  The toolbar window filter handles all
+        // toolbar events.  The parent window filter watches for ConfigureNotify
+        // so we can resize the toolbar when the stack window resizes.
+        gdk_window_add_filter(m_window, _filterFunc,       this);
+        gdk_window_add_filter(m_parent, _parentResizeFunc, this);
+
+        _relayout();
 
         if (m_visible)
-            gtk_widget_show(m_toolbar);
+            gdk_window_show(m_window);
         else
-            gtk_widget_hide(m_toolbar);
+            gdk_window_hide(m_window);
+
+        // Force an initial paint immediately — don't rely on the first Expose
+        // event arriving before the user sees the window.
+        if (m_visible)
+            _redraw();
 #endif
     }
 
     void Destroy() override
     {
 #if GTK_MAJOR_VERSION < 4
-        if (m_toolbar)
-        {
-            gtk_widget_destroy(m_toolbar);
-            m_toolbar = NULL;
-        }
         for (int i = 0; i < m_item_count; i++)
-            m_items[i].~LnxToolbarItemData();
+            m_items[i].~LnxItemData();
         m_item_count = 0;
+        m_hover_idx  = -1;
+
+        if (m_window)
+        {
+            gdk_window_remove_filter(m_window, _filterFunc, this);
+            gdk_window_destroy(m_window);
+            m_window = NULL;
+        }
+        if (m_parent)
+        {
+            gdk_window_remove_filter(m_parent, _parentResizeFunc, this);
+            m_parent = NULL;
+        }
 #endif
     }
+
+    // ── items ────────────────────────────────────────────────────────────────
 
     void AddItem(const MCToolbarItem *p_item) override
     {
 #if GTK_MAJOR_VERSION < 4
-        if (!m_toolbar || m_item_count >= 256)
+        if (!m_window || m_item_count >= 256)
             return;
 
         int t_idx = m_item_count;
-        new (&m_items[t_idx]) LnxToolbarItemData();
-        m_items[t_idx].name.Reset(p_item->GetName());
+        LnxItemData *it = &m_items[t_idx];
+        new (it) LnxItemData();
 
-        GtkToolItem *t_item = NULL;
-        MCToolbarItemStyle t_style = p_item->GetStyle();
+        it->name.Reset(p_item->GetName());
+        it->style   = p_item->GetStyle();
+        it->enabled = p_item->GetEnabled();
 
-        if (t_style == kMCToolbarItemStyleSeparator)
-        {
-            t_item = gtk_separator_tool_item_new();
-        }
-        else if (t_style == kMCToolbarItemStyleSpace ||
-                 t_style == kMCToolbarItemStyleFlexSpace)
-        {
-            t_item = gtk_separator_tool_item_new();
-            gtk_separator_tool_item_set_draw(
-                GTK_SEPARATOR_TOOL_ITEM(t_item), FALSE);
-            if (t_style == kMCToolbarItemStyleFlexSpace)
-                gtk_tool_item_set_expand(t_item, TRUE);
-        }
-        else
-        {
-            // Label
-            MCAutoUTF8String t_label_utf8;
-            const char *t_label_cstr = "";
-            if (p_item->GetLabel() && !MCStringIsEmpty(p_item->GetLabel()))
-                if (t_label_utf8.Lock(p_item->GetLabel()))
-                    t_label_cstr = *t_label_utf8;
+        // Icon from cached PNG bytes
+        MCDataRef t_img = p_item->GetImageData();
+        if (t_img && !MCDataIsEmpty(t_img))
+            it->icon = _pixbufFromPNGData(MCDataGetBytePtr(t_img),
+                                          (uindex_t)MCDataGetLength(t_img));
 
-            GtkToolButton *t_button = GTK_TOOL_BUTTON(
-                gtk_tool_button_new(NULL, t_label_cstr));
+        // Label
+        MCAutoUTF8String t_lbl;
+        if (p_item->GetLabel() && !MCStringIsEmpty(p_item->GetLabel()) &&
+            t_lbl.Lock(p_item->GetLabel()))
+            it->label = strdup(*t_lbl);
 
-            // Icon: prefer cached PNG data from the stack image
-            MCDataRef t_img_data = p_item->GetImageData();
-            if (t_img_data != nil && !MCDataIsEmpty(t_img_data))
-            {
-                GdkPixbuf *t_pixbuf = _pixbufFromPNGData(
-                    MCDataGetBytePtr(t_img_data),
-                    (uindex_t)MCDataGetLength(t_img_data));
-                if (t_pixbuf)
-                {
-                    GtkWidget *t_icon = gtk_image_new_from_pixbuf(t_pixbuf);
-                    g_object_unref(t_pixbuf);
-                    gtk_tool_button_set_icon_widget(t_button, t_icon);
-                    gtk_widget_show(t_icon);
-                }
-            }
-            else if (p_item->GetIcon() && !MCStringIsEmpty(p_item->GetIcon()))
-            {
-                // Fallback: XDG theme icon name
-                MCAutoUTF8String t_icon_utf8;
-                if (t_icon_utf8.Lock(p_item->GetIcon()))
-                {
-                    GtkWidget *t_icon = gtk_image_new_from_icon_name(
-                        *t_icon_utf8, GTK_ICON_SIZE_LARGE_TOOLBAR);
-                    if (t_icon)
-                    {
-                        gtk_tool_button_set_icon_widget(t_button, t_icon);
-                        gtk_widget_show(t_icon);
-                    }
-                }
-            }
-
-            t_item = GTK_TOOL_ITEM(t_button);
-
-            if (!p_item->GetEnabled())
-                gtk_widget_set_sensitive(GTK_WIDGET(t_item), FALSE);
-
-            // Tooltip — skipped; bundled GTK 2 headers predate gtk_widget_set_tooltip_text
-
-            // Store the item name with the button widget so the click callback
-            // can look it up by name rather than by array index.  The index-
-            // based approach breaks after RemoveItem shifts the array.
-            g_object_set_data_full(G_OBJECT(t_button), "item-name",
-                                   (gpointer)MCValueRetain(p_item->GetName()),
-                                   (GDestroyNotify)MCValueRelease);
-            g_object_set_data(G_OBJECT(t_button), "backend", (gpointer)this);
-            g_signal_connect(t_button, "clicked",
-                             G_CALLBACK(_onItemClicked), NULL);
-        }
-
-        m_items[t_idx].widget = t_item;
-        gtk_toolbar_insert(GTK_TOOLBAR(m_toolbar), t_item, -1);
-        gtk_widget_show(GTK_WIDGET(t_item));
         m_item_count++;
+        _relayout();
+        _redraw();
 #endif
     }
 
     void RemoveItem(MCNameRef p_name) override
     {
 #if GTK_MAJOR_VERSION < 4
-        if (!m_toolbar)
-            return;
-
+        int t_found = -1;
         for (int i = 0; i < m_item_count; i++)
         {
-            if (MCNameIsEqualTo(*m_items[i].name, p_name,
-                                kMCCompareCaseless))
+            if (MCNameIsEqualTo(*m_items[i].name, p_name, kMCCompareCaseless))
             {
-                if (m_items[i].widget)
-                {
-                    gtk_container_remove(GTK_CONTAINER(m_toolbar),
-                                        GTK_WIDGET(m_items[i].widget));
-                }
-                m_items[i].~LnxToolbarItemData();
-
-                for (int j = i; j < m_item_count - 1; j++)
-                {
-                    m_items[j].name.Reset(*m_items[j + 1].name);
-                    m_items[j].widget = m_items[j + 1].widget;
-                }
-
-                m_items[m_item_count - 1].~LnxToolbarItemData();
-                new (&m_items[m_item_count - 1]) LnxToolbarItemData();
-
-                m_item_count--;
-                return;
+                t_found = i;
+                break;
             }
         }
+        if (t_found < 0)
+            return;
+
+        m_items[t_found].~LnxItemData();
+
+        // Shift remaining items down, transferring ownership of icon/label.
+        for (int j = t_found; j < m_item_count - 1; j++)
+        {
+            new (&m_items[j]) LnxItemData();
+            m_items[j].name.Reset(*m_items[j + 1].name);
+            m_items[j].style   = m_items[j + 1].style;
+            m_items[j].enabled = m_items[j + 1].enabled;
+            // Transfer GdkPixbuf / label ownership without ref-counting.
+            m_items[j].icon  = m_items[j + 1].icon;
+            m_items[j].label = m_items[j + 1].label;
+            m_items[j + 1].icon  = NULL;  // neutralise before destructor
+            m_items[j + 1].label = NULL;
+            m_items[j + 1].~LnxItemData();
+        }
+
+        // Re-initialise the now-empty last slot.
+        new (&m_items[m_item_count - 1]) LnxItemData();
+        m_item_count--;
+
+        if (m_hover_idx >= m_item_count)
+            m_hover_idx = -1;
+
+        _relayout();
+        _redraw();
 #endif
     }
 
@@ -271,69 +323,31 @@ public:
 #if GTK_MAJOR_VERSION < 4
         for (int i = 0; i < m_item_count; i++)
         {
-            if (MCNameIsEqualTo(*m_items[i].name, p_item->GetName(),
-                                kMCCompareCaseless))
-            {
-                GtkToolItem *t_widget = m_items[i].widget;
-                if (!t_widget)
-                    return;
+            if (!MCNameIsEqualTo(*m_items[i].name, p_item->GetName(),
+                                 kMCCompareCaseless))
+                continue;
 
-                gtk_widget_set_sensitive(GTK_WIDGET(t_widget),
-                                        p_item->GetEnabled() ? TRUE : FALSE);
+            LnxItemData *it = &m_items[i];
 
-                if (GTK_IS_TOOL_BUTTON(t_widget))
-                {
-                    GtkToolButton *t_btn = GTK_TOOL_BUTTON(t_widget);
+            it->enabled = p_item->GetEnabled();
 
-                    // Label
-                    if (p_item->GetLabel())
-                    {
-                        MCAutoUTF8String t_lbl;
-                        if (t_lbl.Lock(p_item->GetLabel()))
-                            gtk_tool_button_set_label(t_btn, *t_lbl);
-                    }
+            // label
+            if (it->label) { free(it->label); it->label = NULL; }
+            MCAutoUTF8String t_lbl;
+            if (p_item->GetLabel() && !MCStringIsEmpty(p_item->GetLabel()) &&
+                t_lbl.Lock(p_item->GetLabel()))
+                it->label = strdup(*t_lbl);
 
-                    // Tooltip — skipped; bundled GTK 2 headers predate gtk_widget_set_tooltip_text
+            // icon
+            if (it->icon) { g_object_unref(it->icon); it->icon = NULL; }
+            MCDataRef t_img = p_item->GetImageData();
+            if (t_img && !MCDataIsEmpty(t_img))
+                it->icon = _pixbufFromPNGData(MCDataGetBytePtr(t_img),
+                                              (uindex_t)MCDataGetLength(t_img));
 
-                    // Icon: reload from cached PNG data
-                    MCDataRef t_img_data = p_item->GetImageData();
-                    if (t_img_data != nil && !MCDataIsEmpty(t_img_data))
-                    {
-                        GdkPixbuf *t_pixbuf = _pixbufFromPNGData(
-                            MCDataGetBytePtr(t_img_data),
-                            (uindex_t)MCDataGetLength(t_img_data));
-                        if (t_pixbuf)
-                        {
-                            GtkWidget *t_icon =
-                                gtk_image_new_from_pixbuf(t_pixbuf);
-                            g_object_unref(t_pixbuf);
-                            gtk_tool_button_set_icon_widget(t_btn, t_icon);
-                            gtk_widget_show(t_icon);
-                        }
-                    }
-                    else if (p_item->GetIcon() && !MCStringIsEmpty(p_item->GetIcon()))
-                    {
-                        // Fallback: XDG theme icon name
-                        MCAutoUTF8String t_icon_utf8;
-                        if (t_icon_utf8.Lock(p_item->GetIcon()))
-                        {
-                            GtkWidget *t_icon = gtk_image_new_from_icon_name(
-                                *t_icon_utf8, GTK_ICON_SIZE_LARGE_TOOLBAR);
-                            if (t_icon)
-                            {
-                                gtk_tool_button_set_icon_widget(t_btn, t_icon);
-                                gtk_widget_show(t_icon);
-                            }
-                        }
-                    }
-                    else
-                    {
-                        // Icon was cleared
-                        gtk_tool_button_set_icon_widget(t_btn, NULL);
-                    }
-                }
-                return;
-            }
+            _relayout();
+            _redraw();
+            return;
         }
 #endif
     }
@@ -341,28 +355,23 @@ public:
     void ClearItems() override
     {
 #if GTK_MAJOR_VERSION < 4
-        if (!m_toolbar)
-            return;
-
         for (int i = 0; i < m_item_count; i++)
-        {
-            if (m_items[i].widget)
-            {
-                gtk_container_remove(GTK_CONTAINER(m_toolbar),
-                                    GTK_WIDGET(m_items[i].widget));
-            }
-            m_items[i].~LnxToolbarItemData();
-        }
+            m_items[i].~LnxItemData();
         m_item_count = 0;
+        m_hover_idx  = -1;
+        if (m_window)
+            _redraw();
 #endif
     }
+
+    // ── state ────────────────────────────────────────────────────────────────
 
     void SetDisplayMode(MCToolbarDisplayMode p_mode) override
     {
         m_display_mode = p_mode;
 #if GTK_MAJOR_VERSION < 4
-        if (m_toolbar)
-            _applyDisplayMode();
+        if (m_window)
+            _redraw();
 #endif
     }
 
@@ -370,71 +379,320 @@ public:
     {
         m_visible = p_visible;
 #if GTK_MAJOR_VERSION < 4
-        if (m_toolbar)
+        if (m_window)
         {
             if (p_visible)
-                gtk_widget_show(m_toolbar);
+                gdk_window_show(m_window);
             else
-                gtk_widget_hide(m_toolbar);
+                gdk_window_hide(m_window);
         }
 #endif
     }
 
-    bool GetVisible() override
-    {
-        return m_visible;
-    }
+    bool GetVisible() override { return m_visible; }
 
 private:
-    MCToolbar              *m_owner;
-    GtkWidget              *m_toolbar;
-    GtkWidget              *m_parent;
-    int                     m_item_count;
-    bool                    m_visible;
-    MCToolbarDisplayMode    m_display_mode;
-    LnxToolbarItemData      m_items[256];
+    MCToolbar           *m_owner;
+    GdkWindow           *m_window;       // toolbar child window
+    GdkWindow           *m_parent;       // owning stack's GdkWindow
+    int                  m_item_count;
+    bool                 m_visible;
+    MCToolbarDisplayMode m_display_mode;
+    int                  m_top_y;        // y offset inside parent
+    int                  m_parent_width;
+    int                  m_hover_idx;    // -1 = none
+    LnxItemData          m_items[256];
 
-    void _applyDisplayMode()
+    // ── layout ───────────────────────────────────────────────────────────────
+
+    void _relayout()
     {
-#if GTK_MAJOR_VERSION < 4
-        if (!m_toolbar)
-            return;
-        GtkToolbarStyle t_style;
-        switch (m_display_mode)
+        // First pass: assign fixed widths.
+        int t_fixed = 0;
+        int t_nflex = 0;
+        for (int i = 0; i < m_item_count; i++)
         {
-            case kMCToolbarDisplayModeIconOnly:
-                t_style = GTK_TOOLBAR_ICONS;
-                break;
-            case kMCToolbarDisplayModeLabelOnly:
-                t_style = GTK_TOOLBAR_TEXT;
-                break;
-            case kMCToolbarDisplayModeIconAndLabel:
-            case kMCToolbarDisplayModeDefault:
-            default:
-                t_style = GTK_TOOLBAR_BOTH;
-                break;
+            switch (m_items[i].style)
+            {
+                case kMCToolbarItemStyleSeparator:
+                    m_items[i].width = kSeparatorWidth;  break;
+                case kMCToolbarItemStyleSpace:
+                    m_items[i].width = kSpaceWidth;      break;
+                case kMCToolbarItemStyleFlexSpace:
+                    m_items[i].width = kFlexSpaceMin;
+                    t_nflex++;
+                    break;
+                default: // button
+                    m_items[i].width = kItemMinWidth;    break;
+            }
+            t_fixed += m_items[i].width;
         }
-        gtk_toolbar_set_style(GTK_TOOLBAR(m_toolbar), t_style);
-#endif
+
+        // Second pass: distribute leftover space to flex items.
+        int t_remain = m_parent_width - t_fixed;
+        if (t_remain > 0 && t_nflex > 0)
+        {
+            int t_extra = t_remain / t_nflex;
+            for (int i = 0; i < m_item_count; i++)
+                if (m_items[i].style == kMCToolbarItemStyleFlexSpace)
+                    m_items[i].width += t_extra;
+        }
+
+        // Third pass: x positions.
+        int t_x = 0;
+        for (int i = 0; i < m_item_count; i++)
+        {
+            m_items[i].x = t_x;
+            t_x += m_items[i].width;
+        }
     }
 
-    // Click callback: reads the item name stored on the button widget so the
-    // lookup is immune to array index shifts caused by RemoveItem.
-    static void _onItemClicked(GtkToolButton *button, gpointer /*user_data*/)
-    {
-        MCToolbarLinuxBackend *t_self =
-            (MCToolbarLinuxBackend *)g_object_get_data(
-                G_OBJECT(button), "backend");
-        MCNameRef t_name =
-            (MCNameRef)g_object_get_data(G_OBJECT(button), "item-name");
+    // ── hit testing ──────────────────────────────────────────────────────────
 
-        if (t_self && t_name && t_self->m_owner)
-            t_self->m_owner->itemClicked(t_name);
+    int _hitTest(int p_x, int /*p_y*/)
+    {
+        for (int i = 0; i < m_item_count; i++)
+        {
+            if (m_items[i].style != kMCToolbarItemStyleButton)
+                continue;
+            if (p_x >= m_items[i].x &&
+                p_x <  m_items[i].x + m_items[i].width)
+                return i;
+        }
+        return -1;
+    }
+
+    // ── drawing ──────────────────────────────────────────────────────────────
+
+    void _redraw()
+    {
+        if (!m_window)
+            return;
+
+        int t_w = gdk_window_get_width(m_window);
+        int t_h = gdk_window_get_height(m_window);
+
+        cairo_t *cr = gdk_cairo_create(m_window);
+        if (!cr)
+            return;
+
+        // Background gradient
+        {
+            cairo_pattern_t *t_grad =
+                cairo_pattern_create_linear(0, 0, 0, t_h);
+            cairo_pattern_add_color_stop_rgb(t_grad, 0.0, 0.93, 0.93, 0.93);
+            cairo_pattern_add_color_stop_rgb(t_grad, 1.0, 0.80, 0.80, 0.80);
+            cairo_set_source(cr, t_grad);
+            cairo_rectangle(cr, 0, 0, t_w, t_h);
+            cairo_fill(cr);
+            cairo_pattern_destroy(t_grad);
+        }
+
+        bool t_show_icon  = (m_display_mode != kMCToolbarDisplayModeLabelOnly);
+        bool t_show_label = (m_display_mode != kMCToolbarDisplayModeIconOnly);
+
+        for (int i = 0; i < m_item_count; i++)
+            _drawItem(cr, i, (m_hover_idx == i), t_show_icon, t_show_label, t_h);
+
+        // Bottom border line
+        cairo_set_source_rgb(cr, 0.55, 0.55, 0.55);
+        cairo_set_line_width(cr, 1.0);
+        cairo_move_to(cr, 0,   t_h - 0.5);
+        cairo_line_to(cr, t_w, t_h - 0.5);
+        cairo_stroke(cr);
+
+        cairo_destroy(cr);
+    }
+
+    void _drawItem(cairo_t *cr, int idx, bool hovered,
+                   bool show_icon, bool show_label, int bar_h)
+    {
+        LnxItemData *it = &m_items[idx];
+        int ix = it->x, iw = it->width;
+
+        // Separator
+        if (it->style == kMCToolbarItemStyleSeparator)
+        {
+            cairo_set_source_rgb(cr, 0.55, 0.55, 0.55);
+            cairo_set_line_width(cr, 1.0);
+            double t_cx = ix + iw / 2.0;
+            cairo_move_to(cr, t_cx, 6);
+            cairo_line_to(cr, t_cx, bar_h - 6);
+            cairo_stroke(cr);
+            return;
+        }
+
+        // Spaces: nothing visible
+        if (it->style != kMCToolbarItemStyleButton)
+            return;
+
+        // Hover highlight
+        if (hovered && it->enabled)
+        {
+            cairo_set_source_rgba(cr, 1.0, 1.0, 1.0, 0.55);
+            cairo_rectangle(cr, ix + 2, 2, iw - 4, bar_h - 4);
+            cairo_fill(cr);
+
+            cairo_set_source_rgba(cr, 0.0, 0.0, 0.0, 0.12);
+            cairo_set_line_width(cr, 1.0);
+            cairo_rectangle(cr, ix + 2.5, 2.5, iw - 5, bar_h - 5);
+            cairo_stroke(cr);
+        }
+
+        double t_alpha = it->enabled ? 1.0 : 0.38;
+        int t_icon_bottom = 0;
+
+        // Icon
+        if (show_icon && it->icon)
+        {
+            int t_src_w = gdk_pixbuf_get_width(it->icon);
+            int t_src_h = gdk_pixbuf_get_height(it->icon);
+
+            double t_scale = 1.0;
+            if (t_src_w > kIconSize || t_src_h > kIconSize)
+                t_scale = (double)kIconSize /
+                          (t_src_w > t_src_h ? t_src_w : t_src_h);
+            int t_dw = (int)(t_src_w * t_scale);
+            int t_dh = (int)(t_src_h * t_scale);
+
+            int t_iy = (show_label && it->label && it->label[0])
+                       ? 4
+                       : (bar_h - t_dh) / 2;
+            int t_icon_x = ix + (iw - t_dw) / 2;
+
+            cairo_save(cr);
+            cairo_translate(cr, t_icon_x, t_iy);
+            if (t_scale != 1.0)
+                cairo_scale(cr, t_scale, t_scale);
+            gdk_cairo_set_source_pixbuf(cr, it->icon, 0, 0);
+            cairo_paint_with_alpha(cr, t_alpha);
+            cairo_restore(cr);
+
+            t_icon_bottom = t_iy + t_dh;
+        }
+
+        // Label — use Pango for proper Unicode rendering
+        if (show_label && it->label && it->label[0])
+        {
+            PangoLayout *t_layout = pango_cairo_create_layout(cr);
+            PangoFontDescription *t_fd =
+                pango_font_description_from_string("Sans 10");
+            pango_layout_set_font_description(t_layout, t_fd);
+            pango_font_description_free(t_fd);
+            pango_layout_set_text(t_layout, it->label, -1);
+
+            int t_pw = 0, t_ph = 0;
+            pango_layout_get_pixel_size(t_layout, &t_pw, &t_ph);
+
+            double t_lx = ix + (iw - t_pw) / 2.0;
+            if (t_lx < ix + 2.0) t_lx = ix + 2.0;
+
+            double t_ly;
+            if (t_icon_bottom > 0)
+                t_ly = (double)(t_icon_bottom + kIconLabelGap);
+            else
+                t_ly = (bar_h - t_ph) / 2.0;
+
+            if (it->enabled)
+                cairo_set_source_rgb(cr, 0.10, 0.10, 0.10);
+            else
+                cairo_set_source_rgba(cr, 0.10, 0.10, 0.10, t_alpha);
+
+            cairo_move_to(cr, t_lx, t_ly);
+            pango_cairo_show_layout(cr, t_layout);
+            g_object_unref(t_layout);
+        }
+    }
+
+    // ── Xlib event filters ───────────────────────────────────────────────────
+
+    // Filter for the toolbar child window.
+    static GdkFilterReturn _filterFunc(GdkXEvent *p_xevent,
+                                       GdkEvent  * /*p_event*/,
+                                       gpointer   p_data)
+    {
+        MCToolbarLinuxBackend *self =
+            static_cast<MCToolbarLinuxBackend *>(p_data);
+        x11::XEvent *xev = static_cast<x11::XEvent *>(p_xevent);
+
+        switch (xev->type)
+        {
+            case Expose:
+                // Redraw only on the last expose in a series (count == 0).
+                if (xev->xexpose.count == 0)
+                    self->_redraw();
+                return GDK_FILTER_REMOVE;
+
+            case ButtonPress:
+                if (xev->xbutton.button == Button1)
+                {
+                    int t_idx = self->_hitTest(xev->xbutton.x, xev->xbutton.y);
+                    if (t_idx >= 0 &&
+                        self->m_items[t_idx].enabled &&
+                        self->m_items[t_idx].style == kMCToolbarItemStyleButton)
+                    {
+                        self->m_owner->itemClicked(
+                            *self->m_items[t_idx].name);
+                    }
+                }
+                return GDK_FILTER_REMOVE;
+
+            case MotionNotify:
+            {
+                int t_old = self->m_hover_idx;
+                self->m_hover_idx =
+                    self->_hitTest(xev->xmotion.x, xev->xmotion.y);
+                if (self->m_hover_idx != t_old)
+                    self->_redraw();
+                return GDK_FILTER_REMOVE;
+            }
+
+            case LeaveNotify:
+                if (self->m_hover_idx != -1)
+                {
+                    self->m_hover_idx = -1;
+                    self->_redraw();
+                }
+                return GDK_FILTER_REMOVE;
+
+            case EnterNotify:
+                // Motion handler will update hover on the first move.
+                return GDK_FILTER_REMOVE;
+
+            default:
+                return GDK_FILTER_CONTINUE;
+        }
+    }
+
+    // Filter on the PARENT (stack) window: watch for ConfigureNotify.
+    static GdkFilterReturn _parentResizeFunc(GdkXEvent *p_xevent,
+                                             GdkEvent  * /*p_event*/,
+                                             gpointer   p_data)
+    {
+        MCToolbarLinuxBackend *self =
+            static_cast<MCToolbarLinuxBackend *>(p_data);
+        x11::XEvent *xev = static_cast<x11::XEvent *>(p_xevent);
+
+        if (xev->type == ConfigureNotify && self->m_window)
+        {
+            int t_new_w = xev->xconfigure.width;
+            if (t_new_w != self->m_parent_width)
+            {
+                self->m_parent_width = t_new_w;
+                gdk_window_resize(self->m_window, t_new_w, kToolbarHeight);
+                self->_relayout();
+                self->_redraw();
+            }
+        }
+
+        // Never consume parent events.
+        return GDK_FILTER_CONTINUE;
     }
 };
 
-////////////////////////////////////////////////////////////////////////////////
+// ─────────────────────────────────────────────────────────────────────────────
 // Factory
+// ─────────────────────────────────────────────────────────────────────────────
 
 MCToolbarBackend *MCToolbarCreatePlatformBackend(MCToolbar *p_owner)
 {

--- a/engine/src/lnx-toolbar.cpp
+++ b/engine/src/lnx-toolbar.cpp
@@ -617,6 +617,15 @@ private:
 
         switch (xev->type)
         {
+            case DestroyNotify:
+                // The toolbar child window has been destroyed — either by
+                // our own Destroy() or because the parent window was
+                // destroyed by the engine (which implicitly destroys all
+                // child X windows).  NULL the pointer now so that Destroy()
+                // does not call GDK functions on a freed GdkWindowObject.
+                self->m_window = NULL;
+                return GDK_FILTER_REMOVE;
+
             case Expose:
                 // Redraw only on the last expose in a series (count == 0).
                 if (xev->xexpose.count == 0)
@@ -672,6 +681,18 @@ private:
         MCToolbarLinuxBackend *self =
             static_cast<MCToolbarLinuxBackend *>(p_data);
         x11::XEvent *xev = static_cast<x11::XEvent *>(p_xevent);
+
+        if (xev->type == DestroyNotify)
+        {
+            // The parent (stack) window is being destroyed.  X automatically
+            // destroys all child windows too, so our toolbar GdkWindow is
+            // gone as well.  NULL both pointers so that Destroy() does not
+            // call GDK functions on freed GdkWindowObjects.
+            self->m_parent = NULL;
+            self->m_window = NULL;
+            // Fall through — let the engine's own DestroyNotify handler run.
+            return GDK_FILTER_CONTINUE;
+        }
 
         if (xev->type == ConfigureNotify && self->m_window)
         {

--- a/engine/src/toolbar.cpp
+++ b/engine/src/toolbar.cpp
@@ -251,9 +251,7 @@ bool MCToolbar::visit_self(MCObjectVisitor *p_visitor)
 
 void MCToolbar::open()
 {
-    fprintf(stderr, "[MCToolbar::open] enter\n"); fflush(stderr);
     MCControl::open();
-    fprintf(stderr, "[MCToolbar::open] after MCControl::open\n"); fflush(stderr);
 
     if (m_backend == nil)
         m_backend = _createBackend();
@@ -267,17 +265,12 @@ void MCToolbar::open()
             t_window = t_stack->getwindow();
 
         m_backend->Create(t_window);
-        fprintf(stderr, "[MCToolbar::open] after Create\n"); fflush(stderr);
         m_backend->SetDisplayMode(m_display_mode);
-        fprintf(stderr, "[MCToolbar::open] after SetDisplayMode\n"); fflush(stderr);
         m_backend->SetVisible(m_toolbar_visible);
-        fprintf(stderr, "[MCToolbar::open] after SetVisible\n"); fflush(stderr);
         // Re-resolve stack image data before syncing — m_image_data is not
         // saved to disk, so it must be rebuilt each time the stack is opened.
         _resolveItemImageData();
-        fprintf(stderr, "[MCToolbar::open] calling _syncBackendItems m_item_count=%u\n", (unsigned)m_item_count); fflush(stderr);
         _syncBackendItems();
-        fprintf(stderr, "[MCToolbar::open] after _syncBackendItems\n"); fflush(stderr);
     }
 }
 

--- a/libfoundation/src/foundation-name.cpp
+++ b/libfoundation/src/foundation-name.cpp
@@ -578,7 +578,6 @@ bool MCNameIsEqualTo(MCNameRef self, MCNameRef p_other_name, MCStringOptions p_o
 
 void __MCNameDestroy(__MCName *self)
 {
-	// Compute the index in the table
 	uindex_t t_index;
 	t_index = __MCNameGetHash(self) & (s_name_table_capacity - 1);
 


### PR DESCRIPTION
Implements MCToolbarLinuxBackend, the Linux platform backend for MCToolbar. The toolbar is rendered as a child GdkWindow positioned at the top of the stack window, drawn entirely with Cairo and Pango. This is architecturally consistent with the rest of the Linux engine, which uses raw GdkWindow* throughout rather than GtkWidgets. engine/src/lnx-toolbar.cpp (new)

Creates a child GdkWindow matching the parent window's visual and colormap, avoiding compositor transparency issues on RGBA-visual stacks Draws a gradient background, separator lines, icon (GdkPixbuf, scaled), and label per item using Cairo Uses pango_cairo_create_layout / pango_cairo_show_layout for label text so Unicode button labels render correctly Registers Xlib event filters for expose (redraw), button press (hit-test → itemClicked), and motion/leave (hover highlight); a second filter on the parent window handles ConfigureNotify for resize Create() is idempotent — calls Destroy() on entry so a second createToolbar without a prior close reinitialises cleanly rather than leaking the old window and double-registering filters Three-pass layout: fixed widths → flex-space distribution → x-position assignment

engine/src/linux.stubs

Added GDK: gdk_window_add_filter, gdk_window_remove_filter, gdk_drawable_get_visual
Added Cairo: cairo_pattern_create_linear, cairo_pattern_add_color_stop_rgb, cairo_set_source, cairo_pattern_destroy, cairo_save, cairo_restore, cairo_translate, cairo_scale, cairo_paint_with_alpha, cairo_set_source_rgb, cairo_set_line_width, cairo_move_to, cairo_line_to, cairo_stroke, cairo_select_font_face, cairo_set_font_size, cairo_text_extents, cairo_show_text; corrected argument types on cairo_set_source_rgba and cairo_rectangle
Added pangocairo: pango_cairo_create_layout, pango_cairo_update_layout, pango_cairo_show_layout
Added pango: pango_layout_get_pixel_size

engine/src/exec-interface.cpp

MCInterfaceExecCreateControl: when p_type == CT_TOOLBAR, walk the stack's controls list before creating anything; if a toolbar already exists, set it to its long ID and return — matching the macOS and Windows no-op behaviour