### PR TITLE
[mac] engine: make `create toolbar` a no-op when toolbar already exists on stack

### DIFF
--- a/engine/src/cmdsc.cpp
+++ b/engine/src/cmdsc.cpp
@@ -587,6 +587,7 @@ void MCCreate::exec_ctxt(MCExecContext& ctxt)
             case CT_TOOLBAR:
             {
                 MCObject *parent = nil;
+                MCStack *t_target_stack = nil;
                 if (container != nil)
                 {
                     uint4 parid;
@@ -600,12 +601,14 @@ void MCCreate::exec_ctxt(MCExecContext& ctxt)
                     {
                         // Toolbar is a stack-level object; use the current
                         // card as the owning parent in the object hierarchy.
-                        parent = static_cast<MCStack *>(t_resolved)->getcurcard();
+                        t_target_stack = static_cast<MCStack *>(t_resolved);
+                        parent = t_target_stack->getcurcard();
                     }
                     else if (t_resolved->gettype() == CT_CARD ||
                              t_resolved->gettype() == CT_GROUP)
                     {
                         parent = t_resolved;
+                        t_target_stack = parent->getstack();
                     }
                     else
                     {
@@ -613,6 +616,29 @@ void MCCreate::exec_ctxt(MCExecContext& ctxt)
                         return;
                     }
                 }
+                else
+                {
+                    t_target_stack = MCdefaultstackptr;
+                }
+
+                // If a toolbar already exists on the target stack, createToolbar
+                // is a no-op — one toolbar per stack window is the limit.
+                if (t_target_stack != nil)
+                {
+                    MCControl *t_ctrl = t_target_stack->getcontrols();
+                    if (t_ctrl != nil)
+                    {
+                        MCControl *t_cur = t_ctrl;
+                        do
+                        {
+                            if (t_cur->gettype() == CT_TOOLBAR)
+                                return;
+                            t_cur = t_cur->next();
+                        }
+                        while (t_cur != t_ctrl);
+                    }
+                }
+
                 MCInterfaceExecCreateControl(ctxt, *t_new_name, otype, parent, visible == False);
                 break;
             }


### PR DESCRIPTION
When `create toolbar` is called on a stack window that already has a toolbar, the command now silently returns without creating a second toolbar object. Previously nothing prevented duplicate toolbars, which caused the original toolbar's items to be lost and left the window with an empty replacement.

The guard is added in the CT_TOOLBAR branch of MCCreate::exec_ctxt (cmdsc.cpp). After the target container is resolved to an MCStack, the stack's flat control list is walked looking for an existing CT_TOOLBAR object. If one is found the command returns immediately; if not, execution falls through to the existing MCInterfaceExecCreateControl path unchanged. All three call forms are covered:
  create toolbar [name]                 -- uses MCdefaultstackptr
  create toolbar [name] in stack "Foo" -- uses the named stack directly
  create toolbar [name] in card "Bar"  -- uses card->getstack()