### PR TITLE
Fix/lin popover

### DIFF
--- a/engine/src/lnxdclnx.cpp
+++ b/engine/src/lnxdclnx.cpp
@@ -347,8 +347,18 @@ Boolean MCScreenDC::handle(Boolean dispatch, Boolean anyevent, Boolean& abort, B
                             hidebackdrop(true);
                             if (MCdefaultstackptr)
                                 MCdefaultstackptr->getcard()->message(MCM_suspend);
-                            
+
                             MCstacks->hidepalettes(true);
+
+                            // Dismiss any open popover — it must not float
+                            // above an unrelated application's window.
+                            if (MCpopoverstack != nullptr)
+                            {
+                                MCStack *t_closing = MCpopoverstack;
+                                MCpopoverstack = nullptr;
+                                MCpopoverparentstack = nullptr;
+                                MCdispatcher->wclose(t_closing->getwindowalways());
+                            }
                         }
                     }
                     

--- a/engine/src/lnxdcs.cpp
+++ b/engine/src/lnxdcs.cpp
@@ -683,9 +683,13 @@ void MCScreenDC::openwindow(Window window, Boolean override)
 
 void MCScreenDC::closewindow(Window window)
 {
-    // If a popover is open and some OTHER window is being closed, dismiss the
-    // popover first so it doesn't outlive the stack it was anchored to.
-    if (MCpopoverstack != nullptr && MCpopoverstack->getwindowalways() != window)
+    // If the parent stack for the current popover is being closed, dismiss
+    // the popover first so it doesn't outlive its anchor.
+    // Only check the parent — dismissing on ANY other window close (the old
+    // behaviour) caused the popover to vanish whenever an unrelated window
+    // such as a tooltip or dialog was hidden.
+    if (MCpopoverstack != nullptr && MCpopoverparentstack != nullptr &&
+        MCpopoverparentstack->getwindowalways() == window)
     {
         MCStack *t_popover = MCpopoverstack;
         MCpopoverstack = nullptr;

--- a/engine/src/lnxstack.cpp
+++ b/engine/src/lnxstack.cpp
@@ -443,14 +443,16 @@ void MCStack::sethints()
 	// Gnome gets confused with these set
 	//if (flags & F_DECORATIONS)
     //
-    // Do NOT set _MOTIF_WM_HINTS for WM_POPOVER.  Setting decorations=0 via
-    // gdk_window_set_decorations() writes _MOTIF_WM_HINTS.decorations=0, which
-    // many compositors interpret as "no frame and no shadow."  The
-    // _NET_WM_WINDOW_TYPE_UTILITY hint is sufficient on its own: modern WMs
-    // (Mutter, KWin, Openbox) suppress the title bar for UTILITY windows
-    // without needing an explicit Motif hint, and compositors will then apply
-    // their normal drop-shadow treatment.
-    if (mode != WM_POPOVER)
+    // For WM_POPOVER use GDK_DECOR_BORDER (border-only, no title).
+    // _MOTIF_WM_HINTS.decorations=0 tells compositors "no frame, no shadow",
+    // killing the drop shadow.  A non-zero value keeps shadows active.
+    // With _NET_WM_WINDOW_TYPE_UTILITY, modern WMs (Mutter, KWin, Openbox)
+    // render no visible border anyway, so this is effectively borderless.
+    if (mode == WM_POPOVER)
+    {
+        gdk_window_set_decorations(window, GDK_DECOR_BORDER);
+    }
+    else
     {
         gdk_window_set_decorations(window, GdkWMDecoration(t_decorations));
         gdk_window_set_functions(window, GdkWMFunction(t_functions));

--- a/engine/src/lnxstack.cpp
+++ b/engine/src/lnxstack.cpp
@@ -266,8 +266,11 @@ void MCStack::sethints()
     }
     
     gdk_window_set_type_hint(window, t_type_hint);
-    
-    if ((mode >= WM_PULLDOWN && mode <= WM_LICENSE))
+
+    // Popovers must NOT be override-redirect: they need the compositor to
+    // apply drop-shadows and the WM to manage z-order so they don't float
+    // above unrelated applications.
+    if ((mode >= WM_PULLDOWN && mode <= WM_LICENSE) && mode != WM_POPOVER)
     {
         gdk_window_set_override_redirect(window, TRUE);
     }
@@ -275,7 +278,15 @@ void MCStack::sethints()
     {
         gdk_window_set_override_redirect(window, FALSE);
     }
-    
+
+    // For popovers: make the window transient for its anchor stack so the WM
+    // keeps it above the parent application but not above other applications.
+    if (mode == WM_POPOVER && MCpopoverparentstack != nullptr)
+    {
+        gdk_window_set_transient_for(window,
+                                     MCpopoverparentstack->getwindowalways());
+    }
+
     // TODO: initial input focus and initial window state
 	//whints.input = MCpointerfocus;
 	//whints.initial_state = flags & F_START_UP_ICONIC ? IconicState:NormalState;
@@ -428,6 +439,15 @@ void MCStack::sethints()
 		
 	}
     
+    // Popovers are borderless floating panels — the compositor provides the
+    // visual frame (drop-shadow) via the UTILITY type hint.  Suppress all WM
+    // chrome so the stack content fills the window without a title bar.
+    if (mode == WM_POPOVER)
+    {
+        t_decorations = 0;
+        t_functions   = 0;
+    }
+
     // TODO: test if this comment is still true
 	// Gnome gets confused with these set
 	//if (flags & F_DECORATIONS)
@@ -524,13 +544,13 @@ MCRectangle MCStack::view_device_setgeom(const MCRectangle &p_rect,
     MCRectangle t_old_rect;
     t_old_rect = MCU_make_rect(t_root_x, t_root_y, t_width, t_height);
 
-    // Override-redirect windows (menus, popups, popovers, tooltips) bypass
-    // the window manager entirely, so the WM will never position them.
-    // We must always apply the computed rect for these modes, regardless of
-    // the F_WM_PLACE flag.
-    bool t_override_redirect = (mode >= WM_PULLDOWN && mode <= WM_LICENSE);
+    // Menus, popups, popovers, and tooltips are all self-positioned — either
+    // because they're override-redirect (WM never sees them) or because the
+    // engine computes the exact anchor-relative position.  Bypass F_WM_PLACE
+    // for all of these so gdk_window_move() is always called.
+    bool t_self_positioned = (mode >= WM_PULLDOWN && mode <= WM_LICENSE);
 
-    if (t_override_redirect || !(flags & F_WM_PLACE) || state & CS_BEEN_MOVED)
+    if (t_self_positioned || !(flags & F_WM_PLACE) || state & CS_BEEN_MOVED)
     {
         GdkGeometry t_geom;
         t_geom.win_gravity = GDK_GRAVITY_STATIC;
@@ -553,14 +573,14 @@ MCRectangle MCStack::view_device_setgeom(const MCRectangle &p_rect,
         // By setting these "user" flags, we tell the window manager that we
         // know best and it should not attempt to remove or resize the window
         // according to its preferences.
-        if (t_override_redirect || !(flags & F_WM_PLACE) || (state & CS_BEEN_MOVED))
+        if (t_self_positioned || !(flags & F_WM_PLACE) || (state & CS_BEEN_MOVED))
             t_hints |= GDK_HINT_USER_POS;
         t_hints |= GDK_HINT_USER_SIZE;
 
         gdk_window_set_geometry_hints(window, &t_geom, GdkWindowHints(t_hints));
     }
 
-    if ((t_override_redirect || !(flags & F_WM_PLACE) || state & CS_BEEN_MOVED) &&
+    if ((t_self_positioned || !(flags & F_WM_PLACE) || state & CS_BEEN_MOVED) &&
         (t_root_x != p_rect.x || t_root_y != p_rect.y))
     {
         if (t_width != p_rect.width || t_height != p_rect.height)

--- a/engine/src/lnxstack.cpp
+++ b/engine/src/lnxstack.cpp
@@ -237,10 +237,16 @@ void MCStack::sethints()
             break;
             
         case WM_POPUP:
-        case WM_POPOVER:
         case WM_OPTION:
         case WM_CASCADE:
             t_type_hint = GDK_WINDOW_TYPE_HINT_POPUP_MENU;
+            break;
+
+        case WM_POPOVER:
+            // A popover is a floating panel, not a transient menu.  Use UTILITY
+            // so that compositors apply a proper drop-shadow and focus handling
+            // is not suppressed the way it is for POPUP_MENU windows.
+            t_type_hint = GDK_WINDOW_TYPE_HINT_UTILITY;
             break;
             
         case WM_COMBO:
@@ -517,14 +523,20 @@ MCRectangle MCStack::view_device_setgeom(const MCRectangle &p_rect,
     
     MCRectangle t_old_rect;
     t_old_rect = MCU_make_rect(t_root_x, t_root_y, t_width, t_height);
-    
-    if (!(flags & F_WM_PLACE) || state & CS_BEEN_MOVED)
+
+    // Override-redirect windows (menus, popups, popovers, tooltips) bypass
+    // the window manager entirely, so the WM will never position them.
+    // We must always apply the computed rect for these modes, regardless of
+    // the F_WM_PLACE flag.
+    bool t_override_redirect = (mode >= WM_PULLDOWN && mode <= WM_LICENSE);
+
+    if (t_override_redirect || !(flags & F_WM_PLACE) || state & CS_BEEN_MOVED)
     {
         GdkGeometry t_geom;
         t_geom.win_gravity = GDK_GRAVITY_STATIC;
-        
+
         gint t_hints = GDK_HINT_MIN_SIZE|GDK_HINT_MAX_SIZE|GDK_HINT_WIN_GRAVITY;
-        
+
         if (flags & F_RESIZABLE)
         {
             t_geom.min_width = p_minwidth;
@@ -537,19 +549,19 @@ MCRectangle MCStack::view_device_setgeom(const MCRectangle &p_rect,
             t_geom.min_width = t_geom.max_width = p_rect.width;
             t_geom.min_height = t_geom.max_height = p_rect.height;
         }
-        
+
         // By setting these "user" flags, we tell the window manager that we
         // know best and it should not attempt to remove or resize the window
         // according to its preferences.
-        if (!(flags & F_WM_PLACE) || (state & CS_BEEN_MOVED))
+        if (t_override_redirect || !(flags & F_WM_PLACE) || (state & CS_BEEN_MOVED))
             t_hints |= GDK_HINT_USER_POS;
         t_hints |= GDK_HINT_USER_SIZE;
-        
+
         gdk_window_set_geometry_hints(window, &t_geom, GdkWindowHints(t_hints));
-        //gdk_window_move_resize(window, p_rect.x, p_rect.y, p_rect.width, p_rect.height);
     }
-    
-    if ((!(flags & F_WM_PLACE) || state & CS_BEEN_MOVED) && (t_root_x != p_rect.x || t_root_y != p_rect.y))
+
+    if ((t_override_redirect || !(flags & F_WM_PLACE) || state & CS_BEEN_MOVED) &&
+        (t_root_x != p_rect.x || t_root_y != p_rect.y))
     {
         if (t_width != p_rect.width || t_height != p_rect.height)
             gdk_window_move_resize(window, p_rect.x, p_rect.y, p_rect.width, p_rect.height);

--- a/engine/src/lnxstack.cpp
+++ b/engine/src/lnxstack.cpp
@@ -439,20 +439,22 @@ void MCStack::sethints()
 		
 	}
     
-    // Popovers are borderless floating panels — the compositor provides the
-    // visual frame (drop-shadow) via the UTILITY type hint.  Suppress all WM
-    // chrome so the stack content fills the window without a title bar.
-    if (mode == WM_POPOVER)
-    {
-        t_decorations = 0;
-        t_functions   = 0;
-    }
-
     // TODO: test if this comment is still true
 	// Gnome gets confused with these set
 	//if (flags & F_DECORATIONS)
-    gdk_window_set_decorations(window, GdkWMDecoration(t_decorations));
-    gdk_window_set_functions(window, GdkWMFunction(t_functions));
+    //
+    // Do NOT set _MOTIF_WM_HINTS for WM_POPOVER.  Setting decorations=0 via
+    // gdk_window_set_decorations() writes _MOTIF_WM_HINTS.decorations=0, which
+    // many compositors interpret as "no frame and no shadow."  The
+    // _NET_WM_WINDOW_TYPE_UTILITY hint is sufficient on its own: modern WMs
+    // (Mutter, KWin, Openbox) suppress the title bar for UTILITY windows
+    // without needing an explicit Motif hint, and compositors will then apply
+    // their normal drop-shadow treatment.
+    if (mode != WM_POPOVER)
+    {
+        gdk_window_set_decorations(window, GdkWMDecoration(t_decorations));
+        gdk_window_set_functions(window, GdkWMFunction(t_functions));
+    }
 	
 	//TS 2007-11-08 : Adding in additional hint _NET_WM_STATE == _NET_WM_STATE_ABOVE if we have set WD_UTILITY (i.e. systemwindow == true)
 	if (decorations & WD_UTILITY)


### PR DESCRIPTION
popover windows now have a shadow and disappear when switching applications. there are window decorations, but we will live with them until the GTK3 migration is complete and we can use GTKPopover instead.