### PR TITLE
Revert removal of revdb functions

### DIFF
--- a/docs/dictionary/function/revdb_closecursor.lcdoc
+++ b/docs/dictionary/function/revdb_closecursor.lcdoc
@@ -1,0 +1,59 @@
+Name: revdb_closecursor
+
+Type: function
+
+Syntax: revdb_closecursor(<recordSetID>)
+
+Summary:
+<execute|Executes> the <revCloseCursor> <command>.
+
+Associations: database library
+
+Introduced: 1.0.0
+
+OS: mac, windows, linux
+
+Platforms: desktop, server
+
+Security: disk, network
+
+Example:
+revdb_closeCursor(3)
+
+Example:
+revdb_closeCursor(finalResults)
+
+Parameters:
+recordSetID:
+The number returned by the revQueryDatabase function when the record set
+was created.
+
+Returns:
+The <revdb_closecursor> <function> returns an error message if the
+closure is not successful. Otherwise, it returns empty.
+
+Description:
+Use the <revdb_closecursor> <function> to clean up after using a 
+<record set>.
+
+Evaluating the <revdb_closecursor> <function> has the same effect as
+<execute|executing> the <revCloseCursor> <command>. The only difference
+is that one is a <function call> and the other is a <command>.
+
+>*Important:*  The <revdb_closecursor> <function> is part of the 
+> <Database library>. To ensure that the <function> works in a 
+> <standalone application>, you must include this 
+> <HyperXTalk custom library|custom library> when you create your 
+> <standalone application|standalone>. In the Inclusions pane of the 
+> <Standalone Application Settings> window, make sure both the 
+> "Database" library checkbox and those of the database drivers you are 
+> using are checked.
+
+References: revCloseCursor (command), function (control structure),
+function call (glossary), Standalone Application Settings (glossary),
+command (glossary), standalone application (glossary), execute (glossary),
+record set (glossary), HyperXTalk custom library (glossary), 
+Database library (library)
+
+Tags: database
+

--- a/docs/dictionary/function/revdb_commit.lcdoc
+++ b/docs/dictionary/function/revdb_commit.lcdoc
@@ -1,0 +1,57 @@
+Name: revdb_commit
+
+Type: function
+
+Syntax: revdb_commit(<databaseID>)
+
+Summary:
+<execute|Executes> the <revCommitDatabase> <command>.
+
+Associations: database library
+
+Introduced: 1.0.0
+
+OS: mac, windows, linux
+
+Platforms: desktop, server
+
+Security: disk, network
+
+Example:
+get revdb_commit(currentDB)
+
+Parameters:
+databaseID:
+The number returned by the revOpenDatabase function when the database
+was opened.
+
+Returns:
+The <revdb_commit> <function> returns empty if the changes were
+successfully saved.
+
+Description:
+Use the <revdb_commit> <function> to commit changes.
+
+Evaluating the <revdb_commit> <function> has the same effect as
+<execute|executing> the <revCommitDatabase> <command>. The only
+difference is that one is a <function call> and the other is a
+<command>. 
+
+>*Important:*  The <revdb_commit> <function> is part of the 
+> <Database library>. To ensure that the <function> works in a 
+> <standalone application>, you must include this 
+> <HyperXTalk custom library|custom library> when you create your 
+> <standalone application|standalone>. In the Inclusions pane of the 
+> <Standalone Application Settings> window, make sure both the 
+> "Database" library checkbox and those of the database drivers you are 
+> using are checked.
+
+References: revCommitDatabase (command), revRollBackDatabase (command),
+function (control structure), revQueryResult (function),
+HyperXTalk custom library (glossary),
+Standalone Application Settings (glossary), command (glossary),
+standalone application (glossary), execute (glossary),
+function call (glossary), Database library (library)
+
+Tags: database
+

--- a/docs/dictionary/function/revdb_disconnect.lcdoc
+++ b/docs/dictionary/function/revdb_disconnect.lcdoc
@@ -1,0 +1,58 @@
+Name: revdb_disconnect
+
+Type: function
+
+Syntax: revdb_disconnect(<databaseID>)
+
+Summary:
+<execute|Executes> the <revCloseDatabase> <command>.
+
+Associations: database library
+
+Introduced: 1.0.0
+
+OS: mac, windows, linux
+
+Platforms: desktop, server
+
+Security: disk, network
+
+Example:
+get revdb_disconnect(savedBudgetDB)
+
+Parameters:
+databaseID:
+The number returned by the revOpenDatabase function when the database
+was opened.
+
+Returns:
+The <revdb_disconnect> <function> returns empty if the closure was
+successful. 
+
+Description:
+Use the <revdb_disconnect> <function> to cleanly log off from a
+<database>. 
+
+Evaluating the <revdb_disconnect> <function> has the same effect as
+<execute|executing> the <revCloseDatabase> <command>. The only
+difference is that one is a <function call> and the other is a
+<command>. 
+
+>*Important:*  The <revdb_disconnect> <function> is part of the 
+> <Database library>. To ensure that the <function> works in a 
+> <standalone application>, you must include this 
+> <HyperXTalk custom library|custom library> when you create your 
+> <standalone application|standalone>. In the Inclusions pane of the 
+> <Standalone Application Settings> window, make sure both the 
+> "Database" library checkbox and those of the database drivers you are 
+> using are checked.
+
+References: revCloseCursor (command), revCloseDatabase (command),
+function (control structure), Standalone Application Settings (glossary),
+database (glossary), command (glossary),
+standalone application (glossary), execute (glossary),
+function call (glossary), HyperXTalk custom library (glossary),
+Database library (library)
+
+Tags: database
+

--- a/docs/dictionary/function/revdb_execute.lcdoc
+++ b/docs/dictionary/function/revdb_execute.lcdoc
@@ -1,0 +1,64 @@
+Name: revdb_execute
+
+Type: function
+
+Syntax: revdb_execute(<databaseID>, <SQLQuery> [, <variablesList>])
+
+Summary:
+<execute|Executes> the <revExecuteSQL> <command>.
+
+Associations: database library
+
+Introduced: 1.0.0
+
+OS: mac, windows, linux
+
+Platforms: desktop, server
+
+Security: disk, network
+
+Example:
+revdb_execute(myDatabaseID,field "Query","*b" & "myvar")
+
+Parameters:
+databaseID:
+The number returned by the revOpenDatabase function when the database
+was opened.
+
+SQLQuery (string):
+A string in Structured Query Language.
+
+variablesList:
+The variablesList consists of one or more variable names (or expressions
+that evaluate to variable names), separated by commas.
+
+Returns:
+The <revdb_execute> <function> returns the number of rows operated on by
+the <SQLQuery>.
+
+Description:
+Use the <revdb_execute> <function> to execute a <SQL query> without
+selecting <record|records>.
+
+Evaluating the <revdb_execute> <function> has the same effect as
+<execute|executing> the <revExecuteSQL> <command>. The only difference
+is that one is a <function call> and the other is a <command>.
+
+>*Important:*  The <revdb_execute> <function> is part of the 
+> <Database library>. To ensure that the <function> works in a 
+> <standalone application>, you must include this 
+> <HyperXTalk custom library|custom library> when you create your 
+> <standalone application|standalone>. In the Inclusions pane of the 
+> <Standalone Application Settings> window, make sure both the 
+> "Database" library checkbox and those of the database drivers you are 
+> using are checked.
+
+References: revExecuteSQL (command), function (control structure),
+execute (glossary), record (glossary),
+Standalone Application Settings (glossary),
+standalone application (glossary), function call (glossary),
+SQL query (glossary), command (glossary),
+HyperXTalk custom library (glossary), Database library (library)
+
+Tags: database
+

--- a/docs/dictionary/function/revdb_movefirst.lcdoc
+++ b/docs/dictionary/function/revdb_movefirst.lcdoc
@@ -1,0 +1,61 @@
+Name: revdb_movefirst
+
+Type: function
+
+Syntax: revdb_movefirst(<recordSetID>)
+
+Summary:
+<execute|Executes> the <revMoveToFirstRecord> <command>.
+
+Associations: database library
+
+Introduced: 1.0.0
+
+OS: mac, windows, linux
+
+Platforms: desktop, server
+
+Security: disk, network
+
+Example:
+revdb_movefirst(savedResults)
+
+Parameters:
+recordSetID:
+The number returned by the revQueryDatabase or revQueryDatabaseBLOB
+function when the record set was created.
+
+Returns:
+The <revdb_movefirst> <function> returns true if it successfully moved
+to the first <record>, false if it could not move to the first <record>
+because there are no <record|records> in the <record set>.
+
+Description:
+Use the <revdb_movefirst> <function> to move around within the selected
+set of <record|records>.
+
+Evaluating the <revdb_movefirst> <function> has the same effect as
+<execute|executing> the <revMoveToFirstRecord> <command>. The only
+difference is that one is a <function call> and the other is a
+<command>. 
+
+>*Important:*  The <revdb_movefirst> <function> is part of the 
+> <Database library>. To ensure that the <function> works in a 
+> <standalone application>, you must include this 
+> <HyperXTalk custom library|custom library> when you create your 
+> <standalone application|standalone>. In the Inclusions pane of the 
+> <Standalone Application Settings> window, make sure both the 
+> "Database" library checkbox and those of the database drivers you are 
+> using are checked.
+
+References: revMoveToLastRecord (command), revMoveToFirstRecord (command),
+revMoveToNextRecord (command), function (control structure),
+revCurrentRecord (function), revCurrentRecordIsFirst (function),
+revCurrentRecordIsLast (function), HyperXTalk custom library (glossary),
+execute (glossary), record set (glossary),
+record (glossary), Standalone Application Settings (glossary),
+standalone application (glossary), function call (glossary),
+command (glossary), Database library (library)
+
+Tags: database
+

--- a/docs/dictionary/function/revdb_movelast.lcdoc
+++ b/docs/dictionary/function/revdb_movelast.lcdoc
@@ -1,0 +1,61 @@
+Name: revdb_movelast
+
+Type: function
+
+Syntax: revdb_movelast(<recordSetID>)
+
+Summary:
+<execute|Executes> the <revMoveToLastRecord> <command>.
+
+Associations: database library
+
+Introduced: 1.0.0
+
+OS: mac, windows, linux
+
+Platforms: desktop, server
+
+Security: disk, network
+
+Example:
+revdb_movelast(mySearch)
+
+Parameters:
+recordSetID:
+The number returned by the revQueryDatabase or revQueryDatabaseBLOB
+function when the record set was created.
+
+Returns:
+The <revdb_movelast> <function> returns true if it successfully moved to
+the last <record>, false if it could not move to the last <record>
+because there are no <record|records> in the <record set>.
+
+Description:
+Use the <revdb_movelast> <function> to move around within the selected
+set of <record|records>.
+
+Evaluating the <revdb_movelast> <function> has the same effect as
+<execute|executing> the <revMoveToLastRecord> <command>. The only
+difference is that one is a <function call> and the other is a
+<command>. 
+
+>*Important:*  The <revdb_movelast> <function> is part of the 
+> <Database library>. To ensure that the <function> works in a 
+> <standalone application>, you must include this 
+> <HyperXTalk custom library|custom library> when you create your 
+> <standalone application|standalone>. In the Inclusions pane of the 
+> <Standalone Application Settings> window, make sure both the 
+> "Database" library checkbox and those of the database drivers you are 
+> using are checked.
+
+References: revMoveToLastRecord (command), revMoveToFirstRecord (command),
+revMoveToNextRecord (command), function (control structure),
+revCurrentRecord (function), revCurrentRecordIsFirst (function),
+revCurrentRecordIsLast (function), HyperXTalk custom library (glossary),
+execute (glossary), record set (glossary),
+record (glossary), Standalone Application Settings (glossary),
+standalone application (glossary), function call (glossary),
+command (glossary), Database library (library)
+
+Tags: database
+

--- a/docs/dictionary/function/revdb_movenext.lcdoc
+++ b/docs/dictionary/function/revdb_movenext.lcdoc
@@ -1,0 +1,60 @@
+Name: revdb_movenext
+
+Type: function
+
+Syntax: revdb_movenext(<recordSetID>)
+
+Summary:
+<execute|Executes> the <revMoveToNextRecord> <command>.
+
+Associations: database library
+
+Introduced: 1.0.0
+
+OS: mac, windows, linux
+
+Platforms: desktop, server
+
+Security: disk, network
+
+Example:
+revdb_movenext(line x of field "Current Recordsets")
+
+Parameters:
+recordSetID:
+The number returned by the revQueryDatabase or revQueryDatabaseBLOB
+function when the record set (database cursor) was created.
+
+Returns:
+The <revdb_movenext> <function> returns true if it successfully moved to
+the next <record>, false if it could not move to the next <record>
+because it's already at the end.
+
+Description:
+Use the <revdb_movenext> <function> to move around within the selected
+set of <record|records>.
+
+Evaluating the <revdb_movenext> <function> has the same effect as
+<execute|executing> the <revMoveToNextRecord> <command>. The only
+difference is that one is a <function call> and the other is a
+<command>. 
+
+>*Important:*  The <revdb_movenext> <function> is part of the 
+> <Database library>. To ensure that the <function> works in a 
+> <standalone application>, you must include this 
+> <HyperXTalk custom library|custom library> when you create your 
+> <standalone application|standalone>. In the Inclusions pane of the 
+> <Standalone Application Settings> window, make sure both the 
+> "Database" library checkbox and those of the database drivers you are 
+> using are checked.
+
+References: revMoveToLastRecord (command), revMoveToFirstRecord (command),
+revMoveToNextRecord (command), function (control structure),
+revCurrentRecord (function), revCurrentRecordIsFirst (function),
+revCurrentRecordIsLast (function), HyperXTalk custom library (glossary),
+record (glossary), Standalone Application Settings (glossary),
+command (glossary), standalone application (glossary), execute (glossary),
+function call (glossary), Database library (library)
+
+Tags: database
+

--- a/docs/dictionary/function/revdb_moveprev.lcdoc
+++ b/docs/dictionary/function/revdb_moveprev.lcdoc
@@ -1,0 +1,61 @@
+Name: revdb_moveprev
+
+Type: function
+
+Syntax: revdb_moveprev(<recordSetID>)
+
+Summary:
+<execute|Executes> the <revMoveToPreviousRecord> <command>.
+
+Associations: database library
+
+Introduced: 1.0.0
+
+OS: mac, windows, linux
+
+Platforms: desktop, server
+
+Security: disk, network
+
+Example:
+revdb_moveprev(testresults)
+
+Parameters:
+recordSetID:
+The number returned by the revQueryDatabase or revQueryDatabaseBLOB
+function when the record set (database cursor) was created.
+
+Returns:
+The <revdb_moveprev> <function> returns true if it successfully moved to
+the previous record, false if it could not move to the next record
+because it's already at the beginning.
+
+Description:
+Use the <revdb_moveprev> <function> to move around within the selected
+set of records.
+
+Evaluating the <revdb_moveprev> <function> has the same effect as
+<execute|executing> the <revMoveToPreviousRecord> <command>. The only
+difference is that one is a <function call> and the other is a
+<command>. 
+
+>*Important:*  The <revdb_moveprev> <function> is part of the 
+> <Database library>. To ensure that the <function> works in a 
+> <standalone application>, you must include this 
+> <HyperXTalk custom library|custom library> when you create your 
+> <standalone application|standalone>. In the Inclusions pane of the 
+> <Standalone Application Settings> window, make sure both the 
+> "Database" library checkbox and those of the database drivers you are 
+> using are checked.
+
+References: revMoveToFirstRecord (command), revMoveToNextRecord (command),
+revMoveToPreviousRecord (command), revMoveToLastRecord (command),
+function (control structure), revCurrentRecord (function),
+revCurrentRecordIsFirst (function), revCurrentRecordIsLast (function),
+HyperXTalk custom library (glossary),
+Standalone Application Settings (glossary), command (glossary),
+standalone application (glossary), execute (glossary),
+function call (glossary), Database library (library)
+
+Tags: database
+

--- a/docs/dictionary/function/revdb_rollback.lcdoc
+++ b/docs/dictionary/function/revdb_rollback.lcdoc
@@ -1,0 +1,58 @@
+Name: revdb_rollback
+
+Type: function
+
+Syntax: revdb_rollback(<databaseID>)
+
+Summary:
+<execute|Executes> the <revRollBackDatabase> <command>.
+
+Associations: database library
+
+Introduced: 1.0.0
+
+OS: mac, windows, linux
+
+Platforms: desktop, server
+
+Security: disk, network
+
+Example:
+revdb_rollback(monthlyExpensesConnection)
+
+Parameters:
+databaseID:
+The number returned by the revOpenDatabase function when the database
+was opened.
+
+Returns:
+The <revdb_rollback> <function> <return|returns> empty if the changes
+were successfully rolled back.
+
+Description:
+Use the <revdb_rollback> <function> to discard changes to a <database>.
+
+Evaluating the <revdb_rollback> <function> has the same effect as
+<execute|executing> the <revRollBackDatabase> <command>. The only
+difference is that one is a <function call> and the other is a
+<command>. 
+
+>*Important:*  The <revdb_rollback> <function> is part of the 
+> <Database library>. To ensure that the <function> works in a 
+> <standalone application>, you must include this 
+> <HyperXTalk custom library|custom library> when you create your 
+> <standalone application|standalone>. In the Inclusions pane of the 
+> <Standalone Application Settings> window, make sure both the 
+> "Database" library checkbox and those of the database drivers you are 
+> using are checked.
+
+References: revert (command), revRollBackDatabase (command),
+revCloseDatabase (command), revCommitDatabase (command),
+function (control structure), return (glossary), database (glossary),
+execute (glossary), Standalone Application Settings (glossary),
+function call (glossary), standalone application (glossary),
+command (glossary), HyperXTalk custom library (glossary),
+Database library (library)
+
+Tags: database
+


### PR DESCRIPTION
This partially reverts commit db370e65dab31cbaedf2eab7c052722033418c94.

revdb function definitions are being retained.