### PR TITLE
[[Issue 302]] Update macScrollEnhancement support for Project Browser

### DIFF
--- a/extensions/script-libraries/macscrollenhancement2/macscrollenhancement2.livecodescript
+++ b/extensions/script-libraries/macscrollenhancement2/macscrollenhancement2.livecodescript
@@ -26,19 +26,19 @@ Author: HyperXTalk
 
 Type: library
 
-Version: 1.0.0
+Version: 1.0.1
 
 Description:
   Generic smooth-scroll library for HyperXTalk.
 
   Intercepts precise trackpad scroll events application-wide via a C
   NSEvent monitor and applies accumulated pixel deltas to whichever
-  scrollable LiveCode control is currently under the mouse ‚Äî fields,
+  scrollable HyperXTalk control is currently under the mouse - fields,
   groups with scrollbars, etc.
 
   Call seScrollEnhancementEnable from any openStack handler that should
   benefit from smooth scrolling. Call seScrollEnhancementDisable from the
-  matching closeStack. Reference-counted ‚Äî the poll keeps running until
+  matching closeStack. Reference-counted - the poll keeps running until
   every caller has disabled it.
 */
 
@@ -72,7 +72,7 @@ end seScrollEnhancementEnable
 /**
 seScrollEnhancementDisable
 Stop smooth scrolling. Call from closeStack (or equivalent).
-Reference-counted ‚Äî poll stops only when every caller has disabled.
+Reference-counted - poll stops only when every caller has disabled.
 */
 command seScrollEnhancementDisable
    if the platform is not "MacOS" then exit seScrollEnhancementDisable
@@ -83,102 +83,46 @@ command seScrollEnhancementDisable
    put 0 into sRefCount   -- clamp in case of unbalanced calls
 end seScrollEnhancementDisable
 
--- ---------------------------------------------------------------------------
--- Internal helpers
--- ---------------------------------------------------------------------------
-
--- LiveCode cannot evaluate a long-id stored in a variable as an object
--- reference directly (e.g. `if tControl is a field` doesn't work). These
--- helpers use `do` to evaluate the property at runtime.
-
-function seObjectKind pObject, pMouseStack
-   -- Returns "field", "group", "button", "card", "stack", or empty.
-   if pObject is empty then return empty
-   local tScript, tResult
-   put "put the name of " & pObject & " of stack " & QUOTE & pMouseStack & QUOTE & " into tResult" into tScript
-   --   do tScript
-   try
-      do tScript
-   catch tErr
-      return empty
-   end try
-   return word 1 of tResult
-end seObjectKind
-
-function seObjectShortName pObject, pMouseStack
-   if pObject is empty then return empty
-   local tScript, tResult
-   --   put "put the short name of " & pObject & " into tResult" into tScript
-   put "put the short name of " & pObject & " of stack " & QUOTE & pMouseStack & QUOTE & " into tResult" into tScript
-   --   do tScript
-   try
-      do tScript
-   catch tErr
-      return empty
-   end try
-   return tResult
-end seObjectShortName
-
-function seObjectOwner pObject, pMouseStack
-   if pObject is empty then return empty
-   local tScript, tResult
-   --   put "put the owner of " & pObject & " into tResult" into tScript
-   put "put the owner of " & pObject & " of stack " & QUOTE & pMouseStack & QUOTE & " into tResult" into tScript
-   --   do tScript
-   try
-      do tScript
-   catch tErr
-      return empty
-   end try
-   return tResult
-end seObjectOwner
-
-function seObjectProp pObject, pMouseStack, pProp
-   if pObject is empty then return empty
-   local tScript, tResult
-   --   put "put the " & pProp & " of " & pObject & " into tResult" into tScript
-   put "put the " & pProp & " of " & pObject & " of stack " & QUOTE & pMouseStack & QUOTE & " into tResult" into tScript
-   --   do tScript
-   try
-      do tScript
-   catch tErr
-      return empty
-   end try
-   return tResult
-end seObjectProp
-
-command seSetObjectProp pObject, pMouseStack, pProp, pValue
-   if pObject is empty then exit seSetObjectProp
-   local tScript
-   put "set the " & pProp & " of " & pObject & " of stack " & QUOTE & pMouseStack & QUOTE & " to " & pValue into tScript
-   do tScript
-end seSetObjectProp
-
 /**
 seGetScrollTarget
 Returns the long id of the best scrollable control under the mouse,
 or empty if there is none. Walks up the owner chain from mouseControl
 to find the first eligible control:
-- A field (always potentially scrollable) ‚Äî except fields inside a
+- A field (always potentially scrollable) - except fields inside a
 group named "Gutter" (line-number display in the script editor).
 - A group that has vScrollbar or hScrollbar set to true.
 */
 function seGetScrollTarget
    local tControl
-   put the mouseControl into tControl
-   
+   try
+      put the long id of the mouseControl into tControl
+   catch tError
+      put empty into tControl
+   end try
+
+   -- Data views like the Project Browser need special handling since 
+   -- the content is not a static group and is generated dynamically
+   if tControl is not empty and the dvcontrol of tControl is not empty then
+      return tControl
+   end if
+
    -- Fallback when mouseControl hasn't updated yet (e.g. right after window opens)
    if tControl is empty and the mouseStack is not empty then
-      local tN, tScript
-      put "put the number of controls of stack " & QUOTE & the mouseStack & QUOTE & " into tN" into tScript
-      do tScript
+      -- Get the selected field on the mousestack.  If mouse is over 
+      -- another control then tControl will get updated.
+      if the selectedfield is not empty and \
+            the long name of the mousestack is the topstack and \
+            the long id of the selectedfield ends with the topstack then
+         put the long id of the selectedfield into tControl
+      end if
+      local tN
+      put the number of controls of the mouseStack into tN
       local tMouseLoc
       put the mouseLoc into tMouseLoc
       repeat with i = tN down to 1
          local tCandidate, tRect
-         put "control " & i & " of stack " & QUOTE & the mouseStack & QUOTE into tCandidate
-         put "put the rect of " & tCandidate & " into tRect" into tScript
-         do tScript
+         put the long id of control i of the mouseStack into tCandidate
+         put the rect of tCandidate into tRect
          if tMouseLoc is within tRect then
             put tCandidate into tControl
             exit repeat
@@ -189,26 +133,34 @@ function seGetScrollTarget
    if tControl is empty then return empty
    repeat
       local tKind
-      put seObjectKind(tControl, the mouseStack) into tKind
+      put word 1 of tControl into tKind
       
       if tKind is "field" then
          -- Skip fields inside the line-number gutter.
          local tParent
-         put seObjectOwner(tControl, the mouseStack) into tParent
-         if seObjectKind(tParent, the mousestack) is "group" and seObjectShortName(tParent, the mouseStack) is "Gutter" then
+         put the long id of the owner of tControl into tParent
+         if word 1 of tParent is "group" and the short name of tParent is "Gutter" then
             put tParent into tControl   -- continue walking up from the gutter group
          else
             return tControl
          end if
          
       else if tKind is "group" then
-         if seObjectProp(tControl, the mouseStack, "vScrollbar") then return tControl
-         if seObjectProp(tControl, the mouseStack, "hScrollbar") then return tControl
-         -- Not a scrolling group ‚Äî walk up.
-         put seObjectOwner(tControl, the mouseStack) into tControl
+         local tHasScrollbar
+         try
+            put the vScrollbar of tControl into tHasScrollbar
+            if tHasScrollbar then return tControl
+         end try
+         try
+            put the hScrollbar of tControl into tHasScrollbar
+            if tHasScrollbar then return tControl
+         end try
+         
+         -- Not a scrolling group - walk up.
+         put the long id of the owner of tControl into tControl
          
       else
-         -- card, stack, or unrecognised ‚Äî stop.
+         -- card, stack, or unrecognised - stop.
          return empty
       end if
       
@@ -222,10 +174,10 @@ If the scrolled control is the Script field of a script editor, syncs
 the line-number gutter to the same vertical scroll position.
 */
 command seSyncGutter pScrolledControl, pNewV
-   if seObjectShortName(pScrolledControl, the mouseStack) is not "Script" then exit seSyncGutter
-   -- Owner chain: field ‚Üí card ‚Üí stack (the script editor).
+   if the short name of pScrolledControl is not "Script" then exit seSyncGutter
+   -- Owner chain: field -> card -> stack (the script editor).
    local tStackName
-   put seObjectShortName(seObjectOwner(seObjectOwner(pScrolledControl, the mouseStack), the mouseStack), the mouseStack) into tStackName
+   put trueword 14 of pScrolledControl into tStackName
    if tStackName is empty then exit seSyncGutter
    if there is not a group "Gutter" of stack tStackName then exit seSyncGutter
    local tOldDefault
@@ -249,7 +201,7 @@ on seScrollPoll
    
    -- Install or remove the C monitor based on whether there is a target.
    -- Keeping the monitor installed when there is a target also blocks
-   -- LiveCode's own coarse line-quantised scroll from reaching the control.
+   -- HyperXTalk's own coarse line-quantised scroll from reaching the control.
    if tScrollTarget is not empty then
       if not sMonitorInstalled then
          macScrollEnhancementInstall the windowId of stack (the mouseStack)
@@ -269,15 +221,26 @@ on seScrollPoll
    put macScrollEnhancementGetDeltaX() into tDeltaX
    
    if tScrollTarget is not empty then
+      -- Special case data views like the Project Browser
+      -- Initial use case only implements vscroll
+      if the dvcontrol of tScrollTarget is not empty then
+         // bounds checking performed by data view so just use raw delta
+         if abs(tDeltaY) > 0.5 then
+            set the viewprop["vscroll"] of tScrollTarget to \
+                  (the viewprop["vscroll"] of tScrollTarget) + tDeltaY
+         end if
+         send "seScrollPoll" to me in 16 milliseconds
+         exit seScrollPoll
+      end if
+      
       -- Suppress scrolling while the script editor handler list popup is
       -- visible. The popup is drawn inside the same NSWindow as the field
       -- so the OS-level window check in the C layer cannot detect it; we
       -- handle it here instead.
       local tHandlerListObj
-      --      put seHandlerListObject() into tHandlerListObj
       try
          put seHandlerListObject() into tHandlerListObj
-      catch tErr
+      catch tError
          put empty into tHandlerListObj
       end try
       if tHandlerListObj is not empty and the visible of tHandlerListObj then
@@ -288,32 +251,26 @@ on seScrollPoll
       -- Apply vertical scroll.
       if abs(tDeltaY) > 0.5 then
          local tCurrentV, tMaxV, tNewV
-         --         put the vScroll of tScrollTarget into tCurrentV
-         put seObjectProp(tScrollTarget, the mouseStack, "vScroll") into tCurrentV
-         --         put the formattedHeight of tScrollTarget - the height of tScrollTarget into tMaxV
-         put seObjectProp(tScrollTarget, the mouseStack, "formattedHeight") - seObjectProp(tScrollTarget, the mouseStack, "height") into tMaxV
+         put the vScroll of tScrollTarget into tCurrentV
+         put the formattedHeight of tScrollTarget - the height of tScrollTarget into tMaxV
          if tMaxV < 0 then put 0 into tMaxV
          put tCurrentV + tDeltaY into tNewV
          if tNewV < 0 then put 0 into tNewV
          if tNewV > tMaxV then put tMaxV into tNewV
-         --         set the vScroll of tScrollTarget to tNewV
-         seSetObjectProp tScrollTarget, the mouseStack, vScroll, tNewV
+         set the vScroll of tScrollTarget to tNewV
          seSyncGutter tScrollTarget, tNewV
       end if
       
       -- Apply horizontal scroll.
       if abs(tDeltaX) > 0.5 then
          local tCurrentH, tMaxH, tNewH
-         --         put the hScroll of tScrollTarget into tCurrentH
-         put seObjectProp(tScrollTarget, the mouseStack, "hScroll") into tCurrentH
-         --         put the formattedWidth of tScrollTarget - the width of tScrollTarget into tMaxH
-         put seObjectProp(tScrollTarget, the mouseStack, "formattedWidth") - seObjectProp(tScrollTarget, the mouseStack, "width") into tMaxH
+         put the hScroll of tScrollTarget into tCurrentH
+         put the formattedWidth of tScrollTarget - the width of tScrollTarget into tMaxH
          if tMaxH < 0 then put 0 into tMaxH
          put tCurrentH + tDeltaX into tNewH
          if tNewH < 0 then put 0 into tNewH
          if tNewH > tMaxH then put tMaxH into tNewH
-         --         set the hScroll of tScrollTarget to tNewH
-         seSetObjectProp tScrollTarget, the mouseStack, hScroll, tNewH
+         set the hScroll of tScrollTarget to tNewH
       end if
    end if
    


### PR DESCRIPTION
Special case data views like the Project Browser to use `viewprop["vscroll"]` to set the `vscroll`.  Bounds checking is performed by the data view so just pass raw updated scroll value.  Only updates if deltaY > .5 to allow tooltips to show.

Handle the case where the mouse is over a card and there is a selected field.

Update code to use `the long id of the mousecontrol` which eliminates the need to use `do script`.

Removed no longer needed internal helpers.

Removed commented out code.

Replaced `‚Äî` with `-` in the script.

Changed version to 1.0.1 due to the changes in how it works.

Closes #302 
Closes #325 