### PR TITLE
fix(popover): re-show NSPopover instead of raising blank backing panel on duplicate open

### DIFF
--- a/engine/src/desktop-dc.cpp
+++ b/engine/src/desktop-dc.cpp
@@ -436,6 +436,18 @@ void MCScreenDC::destroywindow(Window &window)
 
 void MCScreenDC::raisewindow(Window window)
 {
+	// For popover stacks, raising the raw platform window would bring up the
+	// blank backing NSPanel (which has had its content view transferred to the
+	// NSPopover).  Re-show via the popover path instead so the NSPopover is
+	// properly repositioned at the current anchor.  MCpopoveranchor and
+	// MCpopoveredge are set by the caller before openrect is invoked, so they
+	// are current here.
+	MCStack *t_stack = MCdispatcher->findstackd(window);
+	if (t_stack != nil && t_stack->getmode() == WM_POPOVER)
+	{
+		MCPlatformShowWindowAsPopover(window, MCpopoveranchor, (MCPlatformWindowEdge)MCpopoveredge);
+		return;
+	}
 	MCPlatformRaiseWindow(window);
 }
 


### PR DESCRIPTION
When popover stack stackA is called while stackA is already displayed as a popover, openrect takes the "raise existing window" fast-path and calls MCScreen::raisewindow. On macOS, raisewindow was calling MCPlatformRaiseWindow directly on the stack's backing NSPanel — but for popovers, the NSPanel's content view has been transferred to the NSPopover, leaving the panel empty. Raising it produced a blank, immovable, unclosable rectangle window. 

Fix: raisewindow in desktop-dc.cpp now checks whether the target stack is a WM_POPOVER. If so, it calls MCPlatformShowWindowAsPopover (with the already-current MCpopoveranchor/MCpopoveredge) instead of MCPlatformRaiseWindow, which re-presents the NSPopover at the correct anchor position — exactly the same path taken on first show.