### PR TITLE
fix(win): File > Open no longer blocks when saved folder path is gone

### DIFF
--- a/engine/src/w32ans.cpp
+++ b/engine/src/w32ans.cpp
@@ -551,9 +551,25 @@ static int MCA_do_file_dialog(MCStringRef p_title, MCStringRef p_prompt, MCStrin
 			t_hresult = s_shcreateitemfromparsingname(*t_initial_folder_wstr, NULL, __uuidof(IShellItem), (LPVOID *)&t_initial_folder_shellitem);
 			if (SUCCEEDED(t_hresult))
 				t_file_dialog -> SetFolder(t_initial_folder_shellitem);
+			else
+			{
+				// The persisted folder path is no longer accessible (e.g. a
+				// removed USB drive or deleted folder).  Delete the stale registry
+				// entry so the next dialog falls back to Documents instead of
+				// failing silently again.
+				HKEY t_stale_key;
+				if (RegOpenKeyExW(HKEY_CURRENT_USER, L"Software\\HyperXTalk\\FileDialog",
+				                  0, KEY_WRITE, &t_stale_key) == ERROR_SUCCESS)
+				{
+					RegDeleteValueW(t_stale_key, L"LastFolder");
+					RegCloseKey(t_stale_key);
+				}
+			}
 			if (t_initial_folder_shellitem != NULL)
 				t_initial_folder_shellitem -> Release();
-			t_succeeded = SUCCEEDED(t_hresult);
+			// Setting the initial folder is best-effort: do NOT propagate failure
+			// to t_succeeded.  The dialog must still be shown even if the saved
+			// folder path is gone.
 		}
 
 		if (t_succeeded && *t_initial_file != NULL)


### PR DESCRIPTION
answer file was silently returning "cancel" on Windows whenever the folder last persisted in the registry (HKCU\Software\HyperXTalk\FileDialog → LastFolder) was no longer reachable — e.g. after a USB drive was disconnected, a network share went offline, or a folder was deleted. SHCreateItemFromParsingName fails for stale paths, and the original code propagated that failure straight to t_succeeded. Every subsequent if (t_succeeded) guard was then skipped, Show() was never called, and answer file returned "cancel" without displaying any dialog. From the user's perspective, File > Open appeared to do nothing. Fix (engine/src/w32ans.cpp):

Removed t_succeeded = SUCCEEDED(t_hresult) from the SetFolder block. Setting the initial folder is best-effort; the dialog must be shown regardless. Added an else branch that deletes the stale LastFolder registry value when SHCreateItemFromParsingName fails, so the next open/save dialog falls back to the Documents folder rather than hitting the same silent failure again.