### PR TITLE
fix(scripting): add JavaScript alternate language support on arm64 macOS

### DIFF
--- a/engine/src/dskmac.cpp
+++ b/engine/src/dskmac.cpp
@@ -6,6 +6,7 @@
 #include <CoreServices/CoreServices.h>
 #include <CoreFoundation/CoreFoundation.h>
 #import <AppKit/AppKit.h>    // NSRunningApplication, NSWorkspace, NSAppleScript
+#import <JavaScriptCore/JavaScriptCore.h>  // JSContext for do...as "JavaScript"
 
 #include "parsedef.h"
 #include "filedefs.h"
@@ -4062,6 +4063,39 @@ struct MCMacDesktop: public MCSystemInterface, public MCMacSystemService
 			return;
 		}
 
+        // JavaScript via JavaScriptCore (arm64-safe, no Component Manager needed)
+        if (MCStringIsEqualToCString(p_language, "JavaScript", kMCStringOptionCompareCaseless))
+        {
+            MCAutoStringRefAsUTF8String t_script_utf8;
+            if (!t_script_utf8.Lock(p_script))
+            {
+                MCresult->sets("compiler error");
+                return;
+            }
+            NSString *t_ns_script = [NSString stringWithUTF8String: *t_script_utf8];
+            JSContext *t_ctx = [[JSContext alloc] init];
+            JSValue *t_result = [t_ctx evaluateScript: t_ns_script];
+            if (t_ctx.exception != nil)
+            {
+                NSString *t_msg = [t_ctx.exception toString];
+                MCresult->sets(t_msg != nil ? [t_msg UTF8String] : "execution error");
+            }
+            else if (t_result != nil && ![t_result isUndefined] && ![t_result isNull])
+            {
+                NSString *t_str = [t_result toString];
+                if (t_str != nil)
+                    MCresult->sets([t_str UTF8String]);
+                else
+                    MCresult->clear(False);
+            }
+            else
+            {
+                MCresult->clear(False);
+            }
+            [t_ctx release];
+            return;
+        }
+
         getosacomponents();
         OSAcomponent *posacomp = NULL;
         uint2 i;
@@ -4586,15 +4620,18 @@ static OSStatus osaexecute(MCStringRef& r_string, void* /*compinstance*/, OSAID 
 
 static void getosacomponents()
 {
-    // ARM: Component Manager is gone. We register only "applescript"
-    // which is handled natively via NSAppleScript in DoAlternateLanguage.
+    // ARM: Component Manager is gone. We register supported alternate languages
+    // manually. AppleScript is handled via NSAppleScript; JavaScript via JSContext.
     if (osacomponents != NULL)
         return;
-    osacomponents = new (nothrow) OSAcomponent[1];
+    osacomponents = new (nothrow) OSAcomponent[2];
     /* UNCHECKED */ MCStringCreateWithCString("applescript", &osacomponents[0].compname);
     osacomponents[0].compsubtype = 0;
     osacomponents[0].compinstance = NULL;
-    osancomponents = 1;
+    /* UNCHECKED */ MCStringCreateWithCString("javascript", &osacomponents[1].compname);
+    osacomponents[1].compsubtype = 0;
+    osacomponents[1].compinstance = NULL;
+    osancomponents = 2;
 }
 
 struct  LangID2Charset

--- a/engine/src/dskmac.mm
+++ b/engine/src/dskmac.mm
@@ -6,6 +6,7 @@
 #include <CoreServices/CoreServices.h>
 #include <CoreFoundation/CoreFoundation.h>
 #import <AppKit/AppKit.h>    // NSRunningApplication, NSWorkspace, NSAppleScript
+#import <JavaScriptCore/JavaScriptCore.h>  // JSContext for do...as "JavaScript"
 #include <sys/mount.h>
 #include <sys/stat.h>
 
@@ -4070,6 +4071,39 @@ struct MCMacDesktop: public MCSystemInterface, public MCMacSystemService
 			return;
 		}
 
+        // JavaScript via JavaScriptCore (arm64-safe, no Component Manager needed)
+        if (MCStringIsEqualToCString(p_language, "JavaScript", kMCStringOptionCompareCaseless))
+        {
+            MCAutoStringRefAsUTF8String t_script_utf8;
+            if (!t_script_utf8.Lock(p_script))
+            {
+                MCresult->sets("compiler error");
+                return;
+            }
+            NSString *t_ns_script = [NSString stringWithUTF8String: *t_script_utf8];
+            JSContext *t_ctx = [[JSContext alloc] init];
+            JSValue *t_result = [t_ctx evaluateScript: t_ns_script];
+            if (t_ctx.exception != nil)
+            {
+                NSString *t_msg = [t_ctx.exception toString];
+                MCresult->sets(t_msg != nil ? [t_msg UTF8String] : "execution error");
+            }
+            else if (t_result != nil && ![t_result isUndefined] && ![t_result isNull])
+            {
+                NSString *t_str = [t_result toString];
+                if (t_str != nil)
+                    MCresult->sets([t_str UTF8String]);
+                else
+                    MCresult->clear(False);
+            }
+            else
+            {
+                MCresult->clear(False);
+            }
+            [t_ctx release];
+            return;
+        }
+
         getosacomponents();
         OSAcomponent *posacomp = NULL;
         uint2 i;
@@ -4594,15 +4628,18 @@ static OSStatus osaexecute(MCStringRef& r_string, void* /*compinstance*/, OSAID 
 
 static void getosacomponents()
 {
-    // ARM: Component Manager is gone. We register only "applescript"
-    // which is handled natively via NSAppleScript in DoAlternateLanguage.
+    // ARM: Component Manager is gone. We register supported alternate languages
+    // manually. AppleScript is handled via NSAppleScript; JavaScript via JSContext.
     if (osacomponents != NULL)
         return;
-    osacomponents = new (nothrow) OSAcomponent[1];
+    osacomponents = new (nothrow) OSAcomponent[2];
     osacomponents[0].compname = MCSTR("applescript");
     osacomponents[0].compsubtype = 0;
     osacomponents[0].compinstance = NULL;
-    osancomponents = 1;
+    osacomponents[1].compname = MCSTR("javascript");
+    osacomponents[1].compsubtype = 0;
+    osacomponents[1].compinstance = NULL;
+    osancomponents = 2;
 }
 
 struct  LangID2Charset


### PR DESCRIPTION
do "..." as "JavaScript" was throwing alternate language not found on Apple Silicon because the arm64 rewrite of getosacomponents() hardcoded only "applescript" — Component Manager (FindNextComponent) being unavailable on arm64 meant JavaScript was never registered as an available language. 

Fix adds a dedicated JavaScript execution path in DoAlternateLanguage in dskmac.mm that runs the script through JSContext (JavaScriptCore's modern Obj-C API, arm64-native). This gives a full JS environment including standard built-ins like encodeURI and encodeURIComponent. getosacomponents() is updated to register "javascript" as a second supported language so the alternateLanguages reports it correctly.