### PR TITLE
[[Issue 341]] Add `the properties` support for widgets

### DIFF
--- a/engine/src/exec-interface-object.cpp
+++ b/engine/src/exec-interface-object.cpp
@@ -757,6 +757,23 @@ static const PropList videoclipprops[] =
         {"scale", P_SCALE},
     };
 
+static const PropList widgetprops[] =
+    {
+        {"altId", P_ALT_ID},
+        {"behavior", P_PARENT_SCRIPT},
+        {"blendLevel", P_BLEND_LEVEL},
+        {"disabled", P_DISABLED},
+        {"id", P_ID},
+        {"ink", P_INK},
+        {"label", P_LABEL},
+        {"layer", P_LAYER},
+        {"layerMode", P_LAYER_MODE},
+        {"lockLoc", P_LOCK_LOCATION},
+        {"name", P_SHORT_NAME},
+        {"rect", P_RECTANGLE},
+        {"visible", P_VISIBLE},
+    };
+
 ////////////////////////////////////////////////////////////////////////////////
 
 void MCInterfaceLayerParse(MCExecContext& ctxt, MCStringRef p_input, MCInterfaceLayer& r_output)
@@ -3382,9 +3399,8 @@ void MCObject::DoGetProperties(MCExecContext& ctxt, uint32_t part, bool p_effect
         tablesize = ELEMENTS(toolbarprops);
         break;
     case CT_WIDGET:
-		table = NULL;
-		tablesize = 0;
-        // WIDGET-TODO: Implement properties
+        table = widgetprops;
+        tablesize = ELEMENTS(widgetprops);
         break;
 	default:
 		return;

--- a/engine/src/widget.cpp
+++ b/engine/src/widget.cpp
@@ -157,11 +157,6 @@ const char *MCWidget::gettypestring(void)
 	return MCwidgetstring;
 }
 
-const MCObjectPropertyTable *MCWidget::getpropertytable(void) const
-{
-	return &kPropertyTable;
-}
-
 bool MCWidget::visit_self(MCObjectVisitor* p_visitor)
 {
     return p_visitor -> OnWidget(this);

--- a/engine/src/widget.h
+++ b/engine/src/widget.h
@@ -145,7 +145,7 @@ public:
 	virtual Chunk_term gettype(void) const;
 	virtual const char *gettypestring(void);
 
-	virtual const MCObjectPropertyTable *getpropertytable(void) const;
+	virtual const MCObjectPropertyTable *getpropertytable(void) const { return &kPropertyTable; }
     
 	virtual bool visit_self(MCObjectVisitor *p_visitor);
 	


### PR DESCRIPTION
Add basic support to get `the properties` for widgets.  Set has always worked.

```
static const PropList widgetprops[] =
    {
        {"altId", P_ALT_ID},
        {"behavior", P_PARENT_SCRIPT},
        {"blendLevel", P_BLEND_LEVEL},
        {"disabled", P_DISABLED},
        {"id", P_ID},
        {"ink", P_INK},
        {"label", P_LABEL},
        {"layer", P_LAYER},
        {"layerMode", P_LAYER_MODE},
        {"lockLoc", P_LOCK_LOCATION},
        {"name", P_SHORT_NAME},
        {"rect", P_RECTANGLE},
        {"visible", P_VISIBLE},
    };
```

Still will need to `export widget x to array y` to get the state data.

Closes #341 