### PR TITLE
clear the messagebox on openstack

### DIFF
--- a/ide/Toolset/palettes/message box/behaviors/revmessageboxbehavior.livecodescript
+++ b/ide/Toolset/palettes/message box/behaviors/revmessageboxbehavior.livecodescript
@@ -98,6 +98,7 @@ on openStack
    
    __UpdateMessageColors
    __UpdateMessageFont
+	put empty into field "results"
    unlock messages
    unlock screen
 end openStack
@@ -556,6 +557,7 @@ end __UpdateMessageColors
 // picks up the new palette.
 on SystemAppearanceChanged pMode, pWindowColor, pTextColor
    local tBgColor
+   
    put revIDEColor("palette_background") into tBgColor
    set the backgroundColor of me to tBgColor
    set the backgroundColor of this card to tBgColor


### PR DESCRIPTION
On opening the messagebox there's leftover text in the results field.
"dark,#323232,#ffffff"
It's annoying and could be easily remedied by modifying the binary stack, but it seems as easy and maybe better form to add a single line to the openStack handler to empty the field.