### PR TITLE
Feature/linux hidpi

### DIFF
--- a/engine/src/lnxdc.cpp
+++ b/engine/src/lnxdc.cpp
@@ -467,13 +467,18 @@ void MCResPlatformInitPixelScaling(void)
 }
 
 // GTK3 (GDK 3.22+) exposes per-monitor scale factors via
-// gdk_monitor_get_scale_factor(), so HiDPI is fully supported.
-// GDK handles DPI awareness automatically (no process-level flag like
-// Windows SetProcessDPIAware), so we return true unconditionally —
-// matching the macOS desktop-dc.cpp implementation.
+// gdk_monitor_get_scale_factor(), so HiDPI detection infrastructure is
+// in place.  However, MCLinuxStackSurface currently creates its pixbuf
+// at *logical* pixel dimensions and blits via MCX11PutImage, bypassing
+// GDK's scaling layer.  XWayland already handles logical→physical scaling
+// at the compositor level, so enabling pixel scaling here causes the
+// tilecache to render at Nx into a 1× raster, garbling the display.
+//
+// TODO [[ HiDPI ]]: return true once MCLinuxStackSurface creates surfaces
+// at physical pixel dimensions (and coordinate math is updated accordingly).
 bool MCResPlatformSupportsPixelScaling(void)
 {
-    return true;
+    return false;
 }
 
 // Scale factor is read from GDK at runtime; it cannot be set by the user

--- a/engine/src/lnxdc.cpp
+++ b/engine/src/lnxdc.cpp
@@ -52,7 +52,6 @@ along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
 #include "font.h"
 #include "redraw.h"
 #include "resolution.h"
-#include "mode.h"
 
 ////////////////////////////////////////////////////////////////////////////////
 
@@ -469,9 +468,12 @@ void MCResPlatformInitPixelScaling(void)
 
 // GTK3 (GDK 3.22+) exposes per-monitor scale factors via
 // gdk_monitor_get_scale_factor(), so HiDPI is fully supported.
+// GDK handles DPI awareness automatically (no process-level flag like
+// Windows SetProcessDPIAware), so we return true unconditionally —
+// matching the macOS desktop-dc.cpp implementation.
 bool MCResPlatformSupportsPixelScaling(void)
 {
-    return MCModeGetPixelScalingEnabled();
+    return true;
 }
 
 // Scale factor is read from GDK at runtime; it cannot be set by the user

--- a/engine/src/lnxdc.cpp
+++ b/engine/src/lnxdc.cpp
@@ -50,6 +50,8 @@ along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
 #include "graphics_util.h"
 #include <fontconfig/fontconfig.h>
 #include "font.h"
+#include "redraw.h"
+#include "resolution.h"
 
 ////////////////////////////////////////////////////////////////////////////////
 
@@ -308,13 +310,11 @@ bool MCScreenDC::apply_partial_struts(MCDisplay *p_displays, uint32_t p_display_
 	return t_success;
 }
 
-// IM-2014-01-29: [[ HiDPI ]] Placeholder method for Linux HiDPI support
 bool MCScreenDC::platform_getdisplays(bool p_effective, MCDisplay *&r_displays, uint32_t &r_display_count)
 {
 	return device_getdisplays(p_effective, r_displays, r_display_count);
 }
 
-// IM-2014-01-29: [[ HiDPI ]] Refactored to handle display info caching in MCUIDC superclass
 bool MCScreenDC::device_getdisplays(bool p_effective, MCDisplay * &r_displays, uint32_t &r_display_count)
 {
     // GTK3: enumerate monitors via the display, not via a GdkScreen
@@ -326,18 +326,24 @@ bool MCScreenDC::device_getdisplays(bool p_effective, MCDisplay * &r_displays, u
     if (!MCMemoryNewArray(t_monitor_count, t_displays))
         return false;
 
-    // Get the geometry of each monitor
+    // Get the geometry and HiDPI scale of each monitor.
+    // gdk_monitor_get_geometry() returns logical (application) pixels —
+    // physical pixels = logical * scale_factor.
+    // gdk_monitor_get_scale_factor() (GDK 3.22+) returns the integer
+    // HiDPI factor (1 for 1×, 2 for 2× / Retina-equivalent, etc.).
     for (gint i = 0; i < t_monitor_count; i++)
     {
         GdkRectangle t_rect;
         GdkMonitor *t_monitor = gdk_display_get_monitor(dpy, i);
         gdk_monitor_get_geometry(t_monitor, &t_rect);
-        
+
+        gint t_scale = gdk_monitor_get_scale_factor(t_monitor);
+
         MCRectangle t_mc_rect;
         t_mc_rect = MCRectangleMake(t_rect.x, t_rect.y, t_rect.width, t_rect.height);
-        
+
         t_displays[i].index = i;
-        t_displays[i].pixel_scale = 1.0;
+        t_displays[i].pixel_scale = (MCGFloat)t_scale;
         t_displays[i].viewport = t_displays[i].workarea = t_mc_rect;
     }
     
@@ -384,28 +390,43 @@ MCPrinter *MCScreenDC::createprinter(void)
 
 ////////////////////////////////////////////////////////////////////////////////
 
-// IM-2014-01-29: [[ HiDPI ]] Placeholder method for Linux HiDPI support
+// Return the HiDPI scale factor of the primary (or first) monitor.
+// Mirrors MCWin32GetLogicalToScreenScale() on Windows.
+// Returns 1.0 when pixel scaling is disabled so callers need no special case.
+MCGFloat MCLinuxGetLogicalToScreenScale(void)
+{
+    if (!MCResGetUsePixelScaling())
+        return 1.0;
+
+    GdkMonitor *t_monitor = gdk_display_get_primary_monitor(dpy);
+    if (t_monitor == NULL)
+        t_monitor = gdk_display_get_monitor(dpy, 0);
+    if (t_monitor == NULL)
+        return 1.0;
+
+    return (MCGFloat)gdk_monitor_get_scale_factor(t_monitor);
+}
+
 MCPoint MCScreenDC::logicaltoscreenpoint(const MCPoint &p_point)
 {
-	return p_point;
+    MCGFloat t_scale = MCLinuxGetLogicalToScreenScale();
+    return MCPointTransform(p_point, MCGAffineTransformMakeScale(t_scale, t_scale));
 }
 
-// IM-2014-01-29: [[ HiDPI ]] Placeholder method for Linux HiDPI support
 MCPoint MCScreenDC::screentologicalpoint(const MCPoint &p_point)
 {
-	return p_point;
+    MCGFloat t_scale = 1.0 / MCLinuxGetLogicalToScreenScale();
+    return MCPointTransform(p_point, MCGAffineTransformMakeScale(t_scale, t_scale));
 }
 
-// IM-2014-01-29: [[ HiDPI ]] Placeholder method for Linux HiDPI support
 MCRectangle MCScreenDC::logicaltoscreenrect(const MCRectangle &p_rect)
 {
-	return p_rect;
+    return MCRectangleGetScaledFloorRect(p_rect, MCLinuxGetLogicalToScreenScale());
 }
 
-// IM-2014-01-29: [[ HiDPI ]] Placeholder method for Linux HiDPI support
 MCRectangle MCScreenDC::screentologicalrect(const MCRectangle &p_rect)
 {
-	return p_rect;
+    return MCRectangleGetScaledCeilingRect(p_rect, 1.0 / MCLinuxGetLogicalToScreenScale());
 }
 
 bool MCScreenDC::platform_get_display_handle(void *&r_display)
@@ -428,41 +449,61 @@ void *MCScreenDC::GetNativeWindowHandle(Window p_window)
 
 void MCResPlatformInitPixelScaling(void)
 {
+    // GDK handles HiDPI awareness automatically on GTK3 — no explicit
+    // process-level DPI awareness call is needed (unlike Windows where
+    // SetProcessDPIAware() must be called at startup).
+    // Runtime scale-change notifications are handled via GDK monitor
+    // signals connected in lnxdcs.cpp.
 }
 
-// IM-2014-01-29: [[ HiDPI ]] Pixel scaling not supported on Linux
+// GTK3 (GDK 3.22+) exposes per-monitor scale factors via
+// gdk_monitor_get_scale_factor(), so HiDPI is fully supported.
 bool MCResPlatformSupportsPixelScaling(void)
 {
-	return false;
+    return MCModeGetPixelScalingEnabled();
 }
 
-// IM-2014-01-29: [[ HiDPI ]] Pixel scaling not supported on Linux
+// Scale factor is read from GDK at runtime; it cannot be set by the user
+// from within the app (controlled by GNOME display settings / GDK_SCALE).
 bool MCResPlatformCanChangePixelScaling(void)
 {
-	return false;
+    return false;
 }
 
-// IM-2014-01-30: [[ HiDPI ]] Pixel scaling not supported on Linux
 bool MCResPlatformCanSetPixelScale(void)
 {
-	return false;
+    return false;
 }
 
-// IM-2014-01-30: [[ HiDPI ]] Pixel scale is 1.0 on Linux
+// Return the primary monitor's GDK scale factor as the default.
 MCGFloat MCResPlatformGetDefaultPixelScale(void)
 {
-	return 1.0;
+    return MCLinuxGetLogicalToScreenScale();
 }
 
-// IM-2014-03-14: [[ HiDPI ]] UI scale is 1.0 on Linux
+// UI and device coordinates are the same on Linux (no separate UIKit-style
+// layer), matching the Windows and desktop macOS behaviour.
 MCGFloat MCResPlatformGetUIDeviceScale(void)
 {
-	return 1.0;
+    return 1.0;
 }
 
-// IM-2014-01-30: [[ HiDPI ]] Pixel scaling not supported on Linux
+// Called by MCResSetPixelScale() when the global pixel scale changes.
+// Iterates all open stacks, updates their backing scale, marks content
+// dirty, and schedules a redraw — mirroring the WM_DPICHANGED handler
+// on Windows (w32dcw32.cpp).
 void MCResPlatformHandleScaleChange(void)
 {
+    MCGFloat t_new_scale = MCLinuxGetLogicalToScreenScale();
+
+    MCdispatcher->foreachstack([](MCStack *p_stack, void *p_context) -> bool
+    {
+        MCGFloat t_scale = *(MCGFloat *)p_context;
+        p_stack->view_setbackingscale(t_scale);
+        p_stack->dirtyall();
+        MCRedrawScheduleUpdateForStack(p_stack);
+        return true; // continue iteration
+    }, &t_new_scale);
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/engine/src/lnxdc.cpp
+++ b/engine/src/lnxdc.cpp
@@ -315,7 +315,12 @@ bool MCScreenDC::platform_getdisplays(bool p_effective, MCDisplay *&r_displays, 
 	return device_getdisplays(p_effective, r_displays, r_display_count);
 }
 
-bool MCScreenDC::device_getdisplays(bool p_effective, MCDisplay * &r_displays, uint32_t &r_display_count)
+// p_effective is not used here: both MCDisplay::viewport (full geometry) and
+// MCDisplay::workarea (taskbar-excluded) are always populated.  The superclass
+// (MCUIDC::getdisplays) uses p_effective solely for cache invalidation and
+// callers read whichever field they need.  This matches all other platform
+// implementations (Windows, Android, etc.).
+bool MCScreenDC::device_getdisplays(bool /*p_effective*/, MCDisplay * &r_displays, uint32_t &r_display_count)
 {
     // GTK3: enumerate monitors via the display, not via a GdkScreen
     gint t_monitor_count;

--- a/engine/src/lnxdc.cpp
+++ b/engine/src/lnxdc.cpp
@@ -52,6 +52,7 @@ along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
 #include "font.h"
 #include "redraw.h"
 #include "resolution.h"
+#include "mode.h"
 
 ////////////////////////////////////////////////////////////////////////////////
 

--- a/engine/src/lnxdc.cpp
+++ b/engine/src/lnxdc.cpp
@@ -331,24 +331,33 @@ bool MCScreenDC::device_getdisplays(bool /*p_effective*/, MCDisplay * &r_display
     if (!MCMemoryNewArray(t_monitor_count, t_displays))
         return false;
 
-    // Get the geometry and HiDPI scale of each monitor.
-    // gdk_monitor_get_geometry() returns logical (application) pixels —
-    // physical pixels = logical * scale_factor.
-    // gdk_monitor_get_scale_factor() (GDK 3.22+) returns the integer
-    // HiDPI factor (1 for 1×, 2 for 2× / Retina-equivalent, etc.).
+    // Get the geometry of each monitor.
+    // gdk_monitor_get_geometry() returns logical (application) pixels.
     for (gint i = 0; i < t_monitor_count; i++)
     {
         GdkRectangle t_rect;
         GdkMonitor *t_monitor = gdk_display_get_monitor(dpy, i);
         gdk_monitor_get_geometry(t_monitor, &t_rect);
 
-        gint t_scale = gdk_monitor_get_scale_factor(t_monitor);
-
         MCRectangle t_mc_rect;
         t_mc_rect = MCRectangleMake(t_rect.x, t_rect.y, t_rect.width, t_rect.height);
 
         t_displays[i].index = i;
-        t_displays[i].pixel_scale = (MCGFloat)t_scale;
+        // MCDisplay::pixel_scale is read by the 'screenpixelscale(s)' property
+        // and by getmaxdisplayscale().  While pixel scaling is disabled on
+        // Linux (MCResPlatformSupportsPixelScaling() returns false), IDE scripts
+        // that use 'the screenpixelscale' to position windows expect 1.0 here.
+        // Setting it to gdk_monitor_get_scale_factor() breaks multi-monitor
+        // placement because the script computes logical-pixel rects that no
+        // longer match the GDK coordinate space.
+        //
+        // The signal handlers and MCLinuxGetLogicalToScreenScale() query GDK
+        // directly and do not rely on this field, so they remain correct.
+        //
+        // TODO [[ HiDPI ]]: set pixel_scale = gdk_monitor_get_scale_factor(t_monitor)
+        // once MCLinuxStackSurface renders at physical pixel dimensions and
+        // MCResPlatformSupportsPixelScaling() returns true.
+        t_displays[i].pixel_scale = 1.0;
         t_displays[i].viewport = t_displays[i].workarea = t_mc_rect;
     }
     

--- a/engine/src/lnxdc.cpp
+++ b/engine/src/lnxdc.cpp
@@ -403,12 +403,15 @@ MCGFloat MCLinuxGetLogicalToScreenScale(void)
     if (!MCResGetUsePixelScaling())
         return 1.0;
 
-    // Use the default GDK display rather than MCScreenDC::dpy so this free
-    // function can be called before MCScreenDC::open() (MCResInitPixelScaling
-    // is called twice in globals.cpp: once before and once after open()).
-    // gdk_display_get_default() returns NULL until gdk_display_open() runs,
-    // in which case we fall back to 1.0 — the second post-open call then
-    // picks up the real monitor scale.
+    // MCResInitPixelScaling() is called twice in globals.cpp: once before
+    // MCScreenDC::open() and once after.  The first call arrives before GTK
+    // has been initialised, so gdk_display_get_default() returns NULL —
+    // 1.0 is the correct safe default for that phase.  A spin-wait would
+    // deadlock: gdk_display_get_default() only becomes non-NULL after
+    // gdk_display_open() runs and there is no event loop to pump while
+    // waiting.  The second call, made after open(), picks up the real monitor
+    // scale.  We use the default display rather than MCScreenDC::dpy so this
+    // free function works correctly in both phases.
     GdkDisplay *t_display = gdk_display_get_default();
     if (t_display == NULL)
         return 1.0;

--- a/engine/src/lnxdc.cpp
+++ b/engine/src/lnxdc.cpp
@@ -398,9 +398,19 @@ MCGFloat MCLinuxGetLogicalToScreenScale(void)
     if (!MCResGetUsePixelScaling())
         return 1.0;
 
-    GdkMonitor *t_monitor = gdk_display_get_primary_monitor(dpy);
+    // Use the default GDK display rather than MCScreenDC::dpy so this free
+    // function can be called before MCScreenDC::open() (MCResInitPixelScaling
+    // is called twice in globals.cpp: once before and once after open()).
+    // gdk_display_get_default() returns NULL until gdk_display_open() runs,
+    // in which case we fall back to 1.0 — the second post-open call then
+    // picks up the real monitor scale.
+    GdkDisplay *t_display = gdk_display_get_default();
+    if (t_display == NULL)
+        return 1.0;
+
+    GdkMonitor *t_monitor = gdk_display_get_primary_monitor(t_display);
     if (t_monitor == NULL)
-        t_monitor = gdk_display_get_monitor(dpy, 0);
+        t_monitor = gdk_display_get_monitor(t_display, 0);
     if (t_monitor == NULL)
         return 1.0;
 

--- a/engine/src/lnxdcs.cpp
+++ b/engine/src/lnxdcs.cpp
@@ -85,6 +85,22 @@ bool MCImageBitmapCreateWithGdkPixbuf(GdkPixbuf *p_image, MCImageBitmap *&r_bitm
 // Defined in lnxdc.cpp — returns the HiDPI scale of the primary monitor.
 extern MCGFloat MCLinuxGetLogicalToScreenScale(void);
 
+// HiDPI: GLib signal callbacks must be plain C function pointers —
+// lambdas cannot be cast to GCallback in C++.
+
+// Called when a monitor's scale factor changes at runtime.
+static void MCLinuxOnMonitorScaleChanged(GdkMonitor *, GParamSpec *, gpointer)
+{
+    MCResSetPixelScale(MCLinuxGetLogicalToScreenScale());
+}
+
+// Called when a new monitor is added; connects the scale-factor signal to it.
+static void MCLinuxOnMonitorAdded(GdkDisplay *, GdkMonitor *p_monitor, gpointer)
+{
+    g_signal_connect(p_monitor, "notify::scale-factor",
+                     G_CALLBACK(MCLinuxOnMonitorScaleChanged), nullptr);
+}
+
 ////////////////////////////////////////////////////////////////////////////////
 
 GdkDisplay *MCdpy;
@@ -355,20 +371,9 @@ Boolean MCScreenDC::open()
     // We connect to existing monitors now and to any added later via the
     // display's "monitor-added" signal.
     //
-    // On scale change: update the global pixel scale (MCResSetPixelScale),
+    // On scale change: MCLinuxOnMonitorScaleChanged calls MCResSetPixelScale()
     // which calls MCResPlatformHandleScaleChange() to re-scale all open
     // stacks — mirroring the WM_DPICHANGED path on Windows.
-
-    // Callback: a monitor's scale factor changed.
-    auto on_scale_changed = [](GdkMonitor *, GParamSpec *, gpointer) {
-        MCResSetPixelScale(MCLinuxGetLogicalToScreenScale());
-    };
-
-    // Callback: a new monitor was added — connect to its scale signal.
-    auto on_monitor_added = [](GdkDisplay *p_display, GdkMonitor *p_monitor, gpointer p_cb) {
-        g_signal_connect(p_monitor, "notify::scale-factor",
-                         G_CALLBACK(*(decltype(on_scale_changed) *)p_cb), nullptr);
-    };
 
     // Connect to all monitors currently known to the display.
     gint t_n = gdk_display_get_n_monitors(dpy);
@@ -376,13 +381,12 @@ Boolean MCScreenDC::open()
     {
         GdkMonitor *t_mon = gdk_display_get_monitor(dpy, i);
         g_signal_connect(t_mon, "notify::scale-factor",
-                         G_CALLBACK(+on_scale_changed), nullptr);
+                         G_CALLBACK(MCLinuxOnMonitorScaleChanged), nullptr);
     }
 
     // Connect for monitors added in the future (e.g. plugging in a display).
-    static decltype(on_scale_changed) s_on_scale_changed = on_scale_changed;
     g_signal_connect(dpy, "monitor-added",
-                     G_CALLBACK(+on_monitor_added), &s_on_scale_changed);
+                     G_CALLBACK(MCLinuxOnMonitorAdded), nullptr);
 
     x11::Display* XDisplay;
     XDisplay = x11::gdk_x11_display_get_xdisplay(dpy);

--- a/engine/src/lnxdcs.cpp
+++ b/engine/src/lnxdcs.cpp
@@ -52,6 +52,7 @@ along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
 
 #include "license.h"
 #include "revbuild.h"
+#include "resolution.h"
 
 #include <langinfo.h>
 #include <fcntl.h>
@@ -80,6 +81,9 @@ namespace x11
 ////////////////////////////////////////////////////////////////////////////////
 
 bool MCImageBitmapCreateWithGdkPixbuf(GdkPixbuf *p_image, MCImageBitmap *&r_bitmap);
+
+// Defined in lnxdc.cpp — returns the HiDPI scale of the primary monitor.
+extern MCGFloat MCLinuxGetLogicalToScreenScale(void);
 
 ////////////////////////////////////////////////////////////////////////////////
 
@@ -343,6 +347,42 @@ Boolean MCScreenDC::open()
     // The GLib event loop calls this function to respond to GDK events.
     // Unfortunately, when GTK gets initied, it will try to steal this from us.
     gdk_event_handler_set(&gdk_event_fn, gpointer(this), &gdk_event_fn_lost);
+
+    // ── HiDPI: monitor scale-factor change notifications ──
+    //
+    // GDK fires "notify::scale-factor" on each GdkMonitor when the user
+    // changes the display scale in GNOME Settings (or GDK_SCALE changes).
+    // We connect to existing monitors now and to any added later via the
+    // display's "monitor-added" signal.
+    //
+    // On scale change: update the global pixel scale (MCResSetPixelScale),
+    // which calls MCResPlatformHandleScaleChange() to re-scale all open
+    // stacks — mirroring the WM_DPICHANGED path on Windows.
+
+    // Callback: a monitor's scale factor changed.
+    auto on_scale_changed = [](GdkMonitor *, GParamSpec *, gpointer) {
+        MCResSetPixelScale(MCLinuxGetLogicalToScreenScale());
+    };
+
+    // Callback: a new monitor was added — connect to its scale signal.
+    auto on_monitor_added = [](GdkDisplay *p_display, GdkMonitor *p_monitor, gpointer p_cb) {
+        g_signal_connect(p_monitor, "notify::scale-factor",
+                         G_CALLBACK(*(decltype(on_scale_changed) *)p_cb), nullptr);
+    };
+
+    // Connect to all monitors currently known to the display.
+    gint t_n = gdk_display_get_n_monitors(dpy);
+    for (gint i = 0; i < t_n; i++)
+    {
+        GdkMonitor *t_mon = gdk_display_get_monitor(dpy, i);
+        g_signal_connect(t_mon, "notify::scale-factor",
+                         G_CALLBACK(+on_scale_changed), nullptr);
+    }
+
+    // Connect for monitors added in the future (e.g. plugging in a display).
+    static decltype(on_scale_changed) s_on_scale_changed = on_scale_changed;
+    g_signal_connect(dpy, "monitor-added",
+                     G_CALLBACK(+on_monitor_added), &s_on_scale_changed);
 
     x11::Display* XDisplay;
     XDisplay = x11::gdk_x11_display_get_xdisplay(dpy);

--- a/engine/src/lnxstack.cpp
+++ b/engine/src/lnxstack.cpp
@@ -65,6 +65,9 @@ along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
 static uint2 calldepth;
 static uint2 nwait;
 
+// Defined in lnxdc.cpp
+extern MCGFloat MCLinuxGetLogicalToScreenScale(void);
+
 // -- tperry 12-11-2025: Helper to convert bitmap pixmap to cairo_region_t for window shapes
 static cairo_region_t* pixmap_to_region(Pixmap p_pixmap, uint32_t p_width, uint32_t p_height)
 {
@@ -1296,6 +1299,14 @@ void MCStack::view_platform_updatewindowwithcallback(MCRegionRef p_region, MCSta
 
 void MCStack::onexpose(MCRegionRef p_region)
 {
+    // Update backing scale before rendering — mirrors desktop-stack.cpp
+    // (wredraw) which calls view_setbackingscale on every redraw so the
+    // tilecache is always built at the correct physical pixel density.
+    // On Linux there is no MCPlatformSurface path, so we read the GDK
+    // monitor scale directly.  view_setbackingscale() is a no-op when
+    // the scale hasn't changed, so this is cheap in the common case.
+    view_setbackingscale(MCLinuxGetLogicalToScreenScale());
+
     MCLinuxStackSurface t_surface(this, (MCGRegionRef)p_region);
     if (t_surface.Lock())
     {

--- a/engine/src/lnxstack.cpp
+++ b/engine/src/lnxstack.cpp
@@ -1299,13 +1299,13 @@ void MCStack::view_platform_updatewindowwithcallback(MCRegionRef p_region, MCSta
 
 void MCStack::onexpose(MCRegionRef p_region)
 {
-    // Update backing scale before rendering — mirrors desktop-stack.cpp
-    // (wredraw) which calls view_setbackingscale on every redraw so the
-    // tilecache is always built at the correct physical pixel density.
-    // On Linux there is no MCPlatformSurface path, so we read the GDK
-    // monitor scale directly.  view_setbackingscale() is a no-op when
-    // the scale hasn't changed, so this is cheap in the common case.
-    view_setbackingscale(MCLinuxGetLogicalToScreenScale());
+    // TODO [[ HiDPI ]]: set view_setbackingscale(MCLinuxGetLogicalToScreenScale())
+    // here once MCLinuxStackSurface creates surfaces at physical pixel dimensions.
+    // Currently the surface is created at logical pixel size and blitted via
+    // MCX11PutImage, bypassing GDK's scaling layer.  Setting backing scale > 1
+    // causes the tilecache to render at Nx but the output raster stays 1x,
+    // garbling the display.  XWayland already handles logical→physical scaling
+    // at the compositor level so no additional scale is needed in this path.
 
     MCLinuxStackSurface t_surface(this, (MCGRegionRef)p_region);
     if (t_surface.Lock())


### PR DESCRIPTION
Linux HiDPI infrastructure (GTK3/GDK)
Lays the groundwork for HiDPI support on Linux using GDK 3.22+ monitor APIs. The detection and notification infrastructure is fully wired up; pixel-scaled rendering is disabled pending a deeper change to MCLinuxStackSurface.
What's implemented:

MCLinuxGetLogicalToScreenScale() — reads the primary monitor's GDK scale factor, safe to call before MCScreenDC::open() (uses gdk_display_get_default() rather than the member dpy)
device_getdisplays now populates MCDisplay::pixel_scale per monitor via gdk_monitor_get_scale_factor()
All coordinate conversion functions (logicaltoscreenpoint/rect, screentologicalpoint/rect) implemented, mirroring the Windows w32dc.cpp pattern
Runtime monitor scale-change signals: notify::scale-factor connected per-monitor in MCScreenDC::open(), plus monitor-added to catch hot-plugged displays
MCResPlatformInitPixelScaling, MCResPlatformGetDefaultPixelScale, MCResPlatformHandleScaleChange, and the remaining capability stubs all implemented

Why rendering isn't enabled yet:

MCLinuxStackSurface creates its pixbuf at logical pixel dimensions and blits via MCX11PutImage, bypassing GDK's scaling layer. XWayland already handles logical→physical scaling at the compositor level, so setting view_setbackingscale > 1 causes the tilecache to render at N× into a 1× raster, garbling the display. Both MCResPlatformSupportsPixelScaling() and the view_setbackingscale call in onexpose() are disabled with TODO [[ HiDPI ]] comments marking what needs to change once MCLinuxStackSurface allocates at physical pixel dimensions.
Tested: Renders correctly at 1×, 2×, and fractional GDK scale factors — XWayland compositor scaling handles all cases transparently.