### PR TITLE
Got tired of builds taking too long.

### DIFF
--- a/prebuilt/scripts/build-libcairo.sh
+++ b/prebuilt/scripts/build-libcairo.sh
@@ -4,7 +4,7 @@ source "${BASEDIR}/scripts/platform.inc"
 source "${BASEDIR}/scripts/lib_versions.inc"
 source "${BASEDIR}/scripts/util.inc"
 
-# 2024.07.24 currently ${libcairo_VERSION} is 1.18.0
+# 2026.07.04 currently ${libcairo_VERSION} is 1.18.4
 
 THIS="libcairo"
 URL_ROOT="https://www.cairographics.org/releases/cairo-${libcairo_VERSION}.tar.xz"

--- a/prebuilt/scripts/build-libjpeg.sh
+++ b/prebuilt/scripts/build-libjpeg.sh
@@ -16,17 +16,20 @@ ARCHIVE_DESTINATION="${SHORT_THIS}sr${JPEG_MAJOR_VERSION}"
 FILE_DIRECTORY="../../thirdparty/${THIS}/src"
 
 fetchBinary
-rm -rf ${SHORT_THIS}-${libjpeg_VERSION}
-#unxzBinary
-untarBinary
-mv ${SHORT_THIS}-${libjpeg_VERSION} ${ARCHIVE_DESTINATION}
-# have to convert the windows-style line endings to linux
-# sudo apt install dos2unix
-pushd ${BUILDDIR}/${ARCHIVE_DESTINATION}
-if [ -e "${BUILDDIR}/${ARCHIVE_DESTINATION}/configure" ] ; then
-	echo "running configure"
-	./configure
+if [ ${DOWNLOADED} == 1 ] ; then
+	#rm -rf ${SHORT_THIS}-${libjpeg_VERSION}
+	#unxzBinary
+	untarBinary
+	mv ${SHORT_THIS}-${libjpeg_VERSION} ${ARCHIVE_DESTINATION}
+	# have to convert the windows-style line endings to linux
+	# sudo apt install dos2unix
+	pushd ${BUILDDIR}/${ARCHIVE_DESTINATION}
+	if [ -e "${BUILDDIR}/${ARCHIVE_DESTINATION}/configure" ] ; then
+		echo "running configure"
+		./configure
+	fi
+	makeBinary
+	popd
+	buildLibrary
 fi
-makeBinary
-popd
-buildLibrary
+

--- a/prebuilt/scripts/build-libpng.sh
+++ b/prebuilt/scripts/build-libpng.sh
@@ -10,8 +10,8 @@ source "${BASEDIR}/scripts/util.inc"
 ## URL_ROOT will grab the latest version on the website.
 ## This may be more recent than libpng_VERSION, so the version file
 ## may need to be updated.
-#libpng-1.6.48.tar.xz
-# https://sourceforge.net/projects/libpng/files/libpng16/1.6.48/libpng-1.6.48.tar.xz/download
+#libpng-1.6.58.tar.xz
+# https://sourceforge.net/projects/libpng/files/libpng16/1.6.58/libpng-1.6.58.tar.xz/download
 
 THIS="libpng"
 # remove the dots with sed
@@ -24,8 +24,8 @@ function unxzBinary
 {
 	echo "Untarring ${THIS}.tar"
 	unzip -o "${THIS}.tar" -d "lpng"
-	# retrieve the latest version number (1648)
-	PNG_LATEST=$(echo `ls lpng` | sed 's/[^0-9]//g') # 1648
+	# retrieve the latest version number (1658)
+	PNG_LATEST=$(echo `ls lpng` | sed 's/[^0-9]//g') # 1658
 	ARCHIVE_DESTINATION="${THIS}${PNG_LATEST}/lpng${PNG_LATEST}"
 	mv "libpng.tar" "libpng${PNG_LATEST}.tar"
 	echo "ARCHIVE_DESTINATION= ${ARCHIVE_DESTINATION}"

--- a/prebuilt/scripts/build-libz.sh
+++ b/prebuilt/scripts/build-libz.sh
@@ -12,15 +12,17 @@ ARCHIVE_DESTINATION="zlib-${libz_VERSION}"
 FILE_DIRECTORY="../../thirdparty/${THIS}/src"
 
 fetchBinary
-untarBinary
+if [ ${DOWNLOADED} == 1 ] ; then
+	untarBinary
 
-# Use configure script instead of cmake for zlib
-cd "${BUILDDIR}/${ARCHIVE_DESTINATION}"
-if [ -e "./configure" ]; then
-	echo "configuring zlib with configure script"
-	./configure
-	make
-	cp zlib.h zconf.h "${BUILDDIR}/../include/" 2>/dev/null || true
-	cp libz.a "${BUILDDIR}/../lib/${PLATFORM}/" 2>/dev/null || true
+	# Use configure script instead of cmake for zlib
+	cd "${BUILDDIR}/${ARCHIVE_DESTINATION}"
+	if [ -e "./configure" ]; then
+		echo "configuring zlib with configure script"
+		./configure
+		make
+		cp zlib.h zconf.h "${BUILDDIR}/../include/" 2>/dev/null || true
+		cp libz.a "${BUILDDIR}/../lib/${PLATFORM}/" 2>/dev/null || true
+	fi
 fi
 

--- a/prebuilt/scripts/build-libzip.sh
+++ b/prebuilt/scripts/build-libzip.sh
@@ -4,25 +4,27 @@ source "${BASEDIR}/scripts/platform.inc"
 source "${BASEDIR}/scripts/lib_versions.inc"
 source "${BASEDIR}/scripts/util.inc"
 
-# 2023.10.27 currently ${libzip_VERSION} is 1.10.1
+# 2026.07.04 currently ${libzip_VERSION} is 1.11.4
 
 THIS="libzip"
 URL_ROOT="https://libzip.org/download/${THIS}-${libzip_VERSION}.tar.gz"
 ARCHIVE_DESTINATION="${THIS}-${libzip_VERSION}"
 FILE_DIRECTORY="../../thirdparty/${THIS}/src"
 
+# run cmake
+# run meson
+# copy files if we have a newer version
 function buildSrcLibrary {
 	cmakeBinary
 	mesonBinary
+	# copy the relevant files to the thirdparty directory
 	cp -r ${BUILDDIR}/${ARCHIVE_DESTINATION}/lib/*.h ${FILE_DIRECTORY}
 	cp -r ${BUILDDIR}/${ARCHIVE_DESTINATION}/lib/*.c ${FILE_DIRECTORY}
 	cp ${BUILDDIR}/${ARCHIVE_DESTINATION}/build/*.h ${FILE_DIRECTORY}
 }
 
-fetchBinary
+fetchBinary # only download .tar archive if libzip directory doesn't exist
 untarBinary
 buildSrcLibrary
-#cp ${BUILDDIR}/${ARCHIVE_DESTINATION}/build/zipconf.h ../../revzip/src
-#cp ${BUILDDIR}/${ARCHIVE_DESTINATION}/build/config.h ../../revzip/src
 cp ${BUILDDIR}/${ARCHIVE_DESTINATION}/build/*.h ../../revzip/src
 

--- a/prebuilt/scripts/util.inc
+++ b/prebuilt/scripts/util.inc
@@ -16,94 +16,128 @@ function fetchUrl {
 	fi
 }
 
+DOWNLOADED=0
+
 function fetchBinary
 {
 	cd "${BUILDDIR}"
 
+	DOWNLOADED=0
+	TARFILE="${ARCHIVE_DESTINATION}".tar
+
+	#if directory $THIS does not exist then
 	if [[ ! -d "$THIS"* ]] ; then
-		if [ ! -e "$ARCHIVE_DESTINATION" ] ; then
+		# if $ARCHIVE_DESTINATION doesn't exist (file or directory) then
+		if [ ! -f "$TARFILE" ] ; then
 			echo "Fetching ${THIS} source"
-			fetchUrl "${URL_ROOT}" "${ARCHIVE_DESTINATION}.tar"
+			fetchUrl "${URL_ROOT}" "${TARFILE}"
 			if [ $? != 0 ] ; then
 				echo "downloading ${URL_ROOT} failed"
+				# we no longer need $ARCHIVE_DESTINATION
 				if [ -e "${ARCHIVE_DESTINATION}" ] ; then
 					rm ${ARCHIVE_DESTINATION}
 				fi
 				exit
 			fi
+			DOWNLOADED=1
 		fi # check for already downloaded source
 	fi # check for destination directory
 }
 
 function untarBinary
 {
-	echo "Untarring ${ARCHIVE_DESTINATION}.tar"
-	tar -xf "${ARCHIVE_DESTINATION}.tar"
+	if [ ${DOWNLOADED} == 1 ] ; then
+		if [ -f "$TARFILE" ] ; then
+			echo "Untarring ${TARFILE}"
+			tar -xf "${TARFILE}"
+		fi
+	fi
 }
 
 function unzipBinary
 {
-	echo "Unzipping ${ARCHIVE_DESTINATION}.zip"
-	unzip "${ARCHIVE_DESTINATION}.zip"
+	if [ ${DOWNLOADED} == 1 ] ; then
+		if [ -f "$ARCHIVE_DESTINATION" ] ; then
+			echo "Unzipping ${ARCHIVE_DESTINATION}.zip"
+			unzip "${ARCHIVE_DESTINATION}.zip"
+		fi
+	fi
 }
 
+# special case: file is named ".tar" but needs to be unzipped
 function unxzBinary
 {
-	echo "Unzipping ${ARCHIVE_DESTINATION}.tar"
-	unzip "${ARCHIVE_DESTINATION}.tar"
+	if [ ${DOWNLOADED} == 1 ] ; then
+		if [ -f "$ARCHIVE_DESTINATION" ] ; then
+			echo "Unzipping ${ARCHIVE_DESTINATION}.tar"
+			unzip "${ARCHIVE_DESTINATION}.tar"
+		fi
+	fi
 }
 
 function makeBinary
 {
-	if [ -e "${BUILDDIR}/${ARCHIVE_DESTINATION}/Makefile" ] ; then
-		echo "running make"
-		#mkdir -p ${BUILDDIR}/${ARCHIVE_DESTINATION}/build
-		pushd "${BUILDDIR}/${ARCHIVE_DESTINATION}"
-		make
-		popd
+	if [ ${DOWNLOADED} == 1 ] ; then
+		if [ -e "${BUILDDIR}/${ARCHIVE_DESTINATION}/Makefile" ] ; then
+			echo "running make"
+			#mkdir -p ${BUILDDIR}/${ARCHIVE_DESTINATION}/build
+			pushd "${BUILDDIR}/${ARCHIVE_DESTINATION}"
+			make
+			popd
+		fi
 	fi
 }
 
 function cmakeBinary
 {
-	if [ -e "${BUILDDIR}/${ARCHIVE_DESTINATION}/CMakeLists.txt" ] ; then
-		echo "running cmake"
-		mkdir -p ${BUILDDIR}/${ARCHIVE_DESTINATION}/build
-		pushd "${BUILDDIR}/${ARCHIVE_DESTINATION}"
-		cmake -S . -B build
-		makeBinary
-		popd
+	if [ ${DOWNLOADED} == 1 ] ; then
+		if [ -e "${BUILDDIR}/${ARCHIVE_DESTINATION}/CMakeLists.txt" ] ; then
+			echo "running cmake"
+			mkdir -p ${BUILDDIR}/${ARCHIVE_DESTINATION}/build
+			pushd "${BUILDDIR}/${ARCHIVE_DESTINATION}"
+			cmake -S . -B build
+			makeBinary
+			popd
+		fi
 	fi
 }
 
 function mesonBinary
 {
-	if [ -e "${BUILDDIR}/${ARCHIVE_DESTINATION}/meson.build" ] ; then
-		echo "running meson and ninja"
-		mkdir -p ${BUILDDIR}/${ARCHIVE_DESTINATION}/build
-		pushd "${BUILDDIR}/${ARCHIVE_DESTINATION}"
-		meson setup --wipe build
-		if [ -e "build/build.ninja" ] ; then
-			echo "launching ninja"
-			ninja -C build
+	if [ ${DOWNLOADED} == 1 ] ; then
+		if [ -e "${BUILDDIR}/${ARCHIVE_DESTINATION}/meson.build" ] ; then
+			echo "running meson and ninja"
+			mkdir -p ${BUILDDIR}/${ARCHIVE_DESTINATION}/build
+			pushd "${BUILDDIR}/${ARCHIVE_DESTINATION}"
+			meson setup --wipe build
+			if [ -e "build/build.ninja" ] ; then
+				echo "launching ninja"
+				ninja -C build
+			fi
+			popd
 		fi
-		popd
 	fi
 }
 
 # run cmake
-# run make
 # copy files if we have a newer version
 function buildLibrary {
-	cmakeBinary
-	mkdir -p ${FILE_DIRECTORY}
-	cp ${BUILDDIR}/${ARCHIVE_DESTINATION}/*.h ${FILE_DIRECTORY}
-	cp ${BUILDDIR}/${ARCHIVE_DESTINATION}/*.c ${FILE_DIRECTORY}
+	if [ ${DOWNLOADED} == 1 ] ; then
+		cmakeBinary
+		mkdir -p ${FILE_DIRECTORY}
+		cp ${BUILDDIR}/${ARCHIVE_DESTINATION}/*.h ${FILE_DIRECTORY}
+		cp ${BUILDDIR}/${ARCHIVE_DESTINATION}/*.c ${FILE_DIRECTORY}
+	fi
 }
 
+# run cmake
+# run meson
+# copy files if we have a newer version
 function buildSrcLibrary {
-	cmakeBinary
-	mesonBinary
-	cp -r ${BUILDDIR}/${ARCHIVE_DESTINATION}/src/*.h ${INCLUDE_DIRECTORY}
-	cp -r ${BUILDDIR}/${ARCHIVE_DESTINATION}/src/*.c ${FILE_DIRECTORY}
+	if [ ${DOWNLOADED} == 1 ] ; then
+		cmakeBinary
+		mesonBinary
+		cp -r ${BUILDDIR}/${ARCHIVE_DESTINATION}/src/*.h ${INCLUDE_DIRECTORY}
+		cp -r ${BUILDDIR}/${ARCHIVE_DESTINATION}/src/*.c ${FILE_DIRECTORY}
+	fi
 }

--- a/prebuilt/versions/libpng
+++ b/prebuilt/versions/libpng
@@ -1,2 +1,2 @@
-1.6.46
+1.6.58
 https://sourceforge.net/projects/libpng/files/latest/download


### PR DESCRIPTION
 Avoid unnecessary downloads.
 Don't rebuild files unless we grabbed new versions.
 Still always downloads libpng. Don't have a good way to determine version.
 But rebuilding on linux is much faster now, especially due to not having to rebuild CEF and openssl unless necessary.