### PR TITLE
arm64 mac: call applyscroll() in setgeom() so menubar group scrolls out of view

### DIFF
--- a/engine/src/mac-stubs-arm64.mm
+++ b/engine/src/mac-stubs-arm64.mm
@@ -1733,6 +1733,8 @@ void MCStack::setgeom()
         return;
     }
 
+    applyscroll();
+
     MCRectangle t_old_rect;
     t_old_rect = view_getstackviewport();
 

--- a/engine/src/mac-stubs-arm64.mm
+++ b/engine/src/mac-stubs-arm64.mm
@@ -1751,8 +1751,28 @@ void MCStack::sethints() {}
 void MCStack::setsizehints() {}
 void MCStack::enablewindow(bool p_enable) {}
 void MCStack::redrawicon() {}
-void MCStack::applyscroll() {}
-void MCStack::clearscroll() {}
+void MCStack::applyscroll()
+{
+    int32_t t_new_scroll = getnextscroll(false);
+    if (t_new_scroll == m_scroll)
+        return;
+
+    dirtyall();
+    rect.height += m_scroll;
+    m_scroll = t_new_scroll;
+    rect.height -= t_new_scroll;
+    syncscroll();
+    dirtyall();
+}
+
+void MCStack::clearscroll()
+{
+    if (m_scroll == 0)
+        return;
+    rect.height += m_scroll;
+    m_scroll = 0;
+    syncscroll();
+}
 void MCStack::platform_openwindow(Boolean p_override)
 {
     if (MCModeMakeLocalWindows() && window != NULL)


### PR DESCRIPTION
The osxstack.cpp setgeom() calls applyscroll() before adjusting the viewport, but the arm64 stub in mac-stubs-arm64.mm was missing that call. As a result, setting the menubar property on Apple Silicon never triggered the scroll that pushes the menu group above the top of the card.