### PR TITLE
Update revsblibrary.livecodescript

### DIFF
--- a/ide-support/revsblibrary.livecodescript
+++ b/ide-support/revsblibrary.livecodescript
@@ -876,7 +876,7 @@ on revSBDefaultStandaloneSettings pStack, @xSettingsA
    end if
    // HXT
    put revEnvironmentRuntimePath() & "/Mac OS X/arm64/Support/Sample Icons" into tName
-   put tName & "/GenericApplication.icns" into xSettingsA["OSX,iconFile"]
+   if xSettingsA["OSX,iconFile"] = "" then put tName & "/GenericApplication.icns" into xSettingsA["OSX,iconFile"]
    
    if xSettingsA["answerDialog"] = "" then put kAnswerDialog into xSettingsA["answerDialog"]
    if xSettingsA["cursors"] = "" then put kCursors into xSettingsA["cursors"]


### PR DESCRIPTION
Problem

When a custom .icns file was selected in the macOS section of Standalone Application Settings, it was silently discarded on every build. The icon would revert to the default GenericApplication.icns regardless of the user's choice.

Root Cause

In ide-support/revsblibrary.livecodescript, the revSBDefaultStandaloneSettings handler unconditionally overwrote OSX,iconFile with the generic icon path every time it was called — which happens on every build via revSBGetSettings. Unlike every other default setting in the same handler, it had no if xSettingsA["OSX,iconFile"] = "" then guard.

Fix

Added the missing guard so the generic icon is only set as a default when no custom icon has been configured:

livecode
if xSettingsA["OSX,iconFile"] = "" then put tName & "/GenericApplication.icns" into xSettingsA["OSX,iconFile"]

Testing

Set a custom .icns file in Standalone Settings → macOS section
Build a macOS standalone
Verify the app bundle uses the custom icon instead of the default