### PR TITLE
Extension Build Fix

### DIFF
--- a/extensions/extensions.gyp
+++ b/extensions/extensions.gyp
@@ -107,7 +107,12 @@
 										
 					'outputs':
 					[
-						'<(PRODUCT_DIR)/packaged_extensions/com.livecode.library.<(RULE_INPUT_ROOT)/<(RULE_INPUT_ROOT).livecodescript',	
+						# hack because gyp wants an output
+                        '<(RULE_INPUT_ROOT)-notarealfile.txt',
+                        # Since we have both LiveCode and HyperXTalk extensions, a single
+                        # path does not work.  The below resulted in empty directories
+                        # for HyperXTalk extensions using the `livecode` name.
+						#'<(PRODUCT_DIR)/packaged_extensions/com.livecode.library.<(RULE_INPUT_ROOT)/<(RULE_INPUT_ROOT).livecodescript',	
 					],
 					          
 					'action':


### PR DESCRIPTION
Make an update to the `extensions.gyp` file to prevent creation of `com.livecode.library.xxxx` directories for HyperXTalk script libraries.  The files and folders are created by the process and the tree is moved/copied by makefiles.