### PR TITLE
Fix painted images disappearing when navigating away from card

### DIFF
--- a/engine/src/card.cpp
+++ b/engine/src/card.cpp
@@ -2498,6 +2498,10 @@ MCImage *MCCard::createimage()
 {
 	MCtemplateimage->setrect(rect);
 	MCImage *iptr = new (nothrow) MCImage(*MCtemplateimage);
+	// Assign a proper ID so the MCObjptr can resolve this image after
+	// card close/reopen (clearref() nulls the pointer; getref() re-binds
+	// by ID — without an ID the image is permanently lost on navigation).
+	iptr->setid(getstack()->newid());
 	getstack()->appendcontrol(iptr);
 	mfocused = newcontrol(iptr, False);
 	return iptr;

--- a/engine/src/stack3.cpp
+++ b/engine/src/stack3.cpp
@@ -1171,6 +1171,13 @@ Exec_stat MCStack::setcard(MCCard *card, Boolean recent, Boolean dynamic)
 		curcard->open();
 		
         
+		// Commit any in-progress paint edit before closing the old card.
+		// Without this, the mutable image rep is never serialised: the painted
+		// image object exists on the card but its bitmap data is lost when the
+		// stack is saved and reloaded (or when the card is revisited).
+		if (MCeditingimage)
+			MCeditingimage->finishediting();
+
 		// MW-2011-11-23: [[ Bug ]] Close the old card here to ensure no players
 		//   linger longer than they should.
 		oldcard -> close();


### PR DESCRIPTION
Root cause: MCCard::createimage() never called setid() on the new image. After card close, MCObjptr::clearref() nulls the cached pointer; on reopen getref() re-binds by ID — with ID=0 the lookup always fails and the image is permanently lost.

Fix: assign a proper stack-unique ID in createimage() before the image is registered via newcontrol(), matching what every other tool's creation path already does.

Also call finishediting() on MCeditingimage in setcard() before closing the old card, ensuring the mutable image rep is committed to a serialisable format at navigation time rather than relying solely on recompress() inside MCImage::close().