### PR TITLE
380 unable to paste formatted text into field

### DIFF
--- a/engine/src/dskmac.cpp
+++ b/engine/src/dskmac.cpp
@@ -3625,13 +3625,18 @@ struct MCMacDesktop: public MCSystemInterface, public MCMacSystemService
         CFIndex t_char_count = CFStringGetLength(t_cf_str);
         CFIndex t_byte_count = t_char_count * (CFIndex)sizeof(UniChar);
         if (t_byte_count > (CFIndex)p_output_length)
-            t_byte_count = (CFIndex)p_output_length;
+        {
+            // Buffer too small — report required size so the caller can resize and retry.
+            r_used = (uint4)t_byte_count;
+            CFRelease(t_cf_str);
+            return false;
+        }
         CFStringGetCharacters(t_cf_str,
-            CFRangeMake(0, t_byte_count / (CFIndex)sizeof(UniChar)),
+            CFRangeMake(0, t_char_count),
             (UniChar *)p_output);
         CFRelease(t_cf_str);
         r_used = (uint4)t_byte_count;
-        
+
         return true;
     }
     

--- a/engine/src/dskmac.cpp
+++ b/engine/src/dskmac.cpp
@@ -3615,8 +3615,11 @@ struct MCMacDesktop: public MCSystemInterface, public MCMacSystemService
         
         // ARM replacement: use CFString for legacy encoding → Unicode
         CFStringEncoding t_cf_enc = (CFStringEncoding)t_encoding;
+        fprintf(stderr, "[RTF-tcu] TextConvertToUnicode: enc=%d cf_enc=%u inlen=%u outlen=%u\n",
+            (int)t_encoding, (unsigned)t_cf_enc, (unsigned)p_input_length, (unsigned)p_output_length);
         CFStringRef t_cf_str = CFStringCreateWithBytes(kCFAllocatorDefault,
             (const UInt8 *)p_input, (CFIndex)p_input_length, t_cf_enc, false);
+        fprintf(stderr, "[RTF-tcu] CFStringCreateWithBytes result=%s\n", t_cf_str ? "OK" : "NULL");
         if (t_cf_str == NULL)
         {
             r_used = 0;
@@ -3624,6 +3627,7 @@ struct MCMacDesktop: public MCSystemInterface, public MCMacSystemService
         }
         CFIndex t_char_count = CFStringGetLength(t_cf_str);
         CFIndex t_byte_count = t_char_count * (CFIndex)sizeof(UniChar);
+        fprintf(stderr, "[RTF-tcu] chars=%ld bytes=%ld outlen=%u\n", (long)t_char_count, (long)t_byte_count, (unsigned)p_output_length);
         if (t_byte_count > (CFIndex)p_output_length)
         {
             // Buffer too small — report required size so the caller can resize and retry.

--- a/engine/src/dskmac.mm
+++ b/engine/src/dskmac.mm
@@ -3635,13 +3635,18 @@ struct MCMacDesktop: public MCSystemInterface, public MCMacSystemService
         CFIndex t_char_count = CFStringGetLength(t_cf_str);
         CFIndex t_byte_count = t_char_count * (CFIndex)sizeof(UniChar);
         if (t_byte_count > (CFIndex)p_output_length)
-            t_byte_count = (CFIndex)p_output_length;
+        {
+            // Buffer too small — report required size so the caller can resize and retry.
+            r_used = (uint4)t_byte_count;
+            CFRelease(t_cf_str);
+            return false;
+        }
         CFStringGetCharacters(t_cf_str,
-            CFRangeMake(0, t_byte_count / (CFIndex)sizeof(UniChar)),
+            CFRangeMake(0, t_char_count),
             (UniChar *)p_output);
         CFRelease(t_cf_str);
         r_used = (uint4)t_byte_count;
-        
+
         return true;
     }
     

--- a/engine/src/fieldh.cpp
+++ b/engine/src/fieldh.cpp
@@ -887,12 +887,12 @@ bool MCField::converttoparagraphs(void *p_context, const MCTextParagraph *p_para
 	{
 		// Append the block to the current paragraph
 		MCAutoStringRef t_text;
-        
+
         if (p_block -> string_native)
             /* UNCHECKED */ MCStringCreateWithNativeChars((const char_t*)p_block->string_buffer, p_block->string_length, &t_text);
         else
             /* UNCHECKED */ MCStringCreateWithChars((const unichar_t*)p_block->string_buffer, p_block->string_length, &t_text);
-        
+
 		MCBlock *t_block = t_paragraph->AppendText(*t_text);
 
 		// MW-2008-06-12: [[ Bug 6397 ]] Pasting styled text munges the color.


### PR DESCRIPTION
Fix RTF paste losing text when pasting formatted text into a field on Mac

Problem

When copying formatted text (different colors, bold, etc.) from TextEdit and pasting into a label field on macOS ARM, the cursor would move down the correct number of lines but no text would appear. Plain text paste worked fine; RTF paste was broken only on Mac.

Root cause

The RTF paste pipeline converts Windows-1252 encoded bytes to UTF-16 via TextConvertToUnicode in dskmac.mm. This function uses a two-pass approach: the first call probes the required buffer size, the caller resizes, then a second call does the actual conversion.

The bug was in dskmac.mm (the Objective-C++ file compiled on Mac — distinct from dskmac.cpp). When the output buffer was too small, the code clipped the output byte count to 0 and returned true, indicating success. The caller interpreted this as a successful zero-byte conversion, advanced by nothing, cleared the input, and moved on — silently discarding all text content. The resize-and-retry path was never reached.

Fix

When the required output size exceeds the available buffer, return false with r_used set to the required byte count. RTFText::Flush() already handles this correctly: it calls Ensure(r_used) to grow the buffer, then retries the conversion. The second call succeeds and the text flows through to the field.

The same fix is applied to dskmac.cpp for consistency, though that file is not compiled on Mac.

Testing

Verified that copying formatted text (multiple colors, bold) from TextEdit and pasting into a field now correctly pastes all text with formatting preserved.