### PR TITLE
397 the ide displays large numbers in an array using scientific notation

### DIFF
--- a/extensions/widgets/treeview/treeview.lcb
+++ b/extensions/widgets/treeview/treeview.lcb
@@ -1939,7 +1939,9 @@ private handler calculateMoreElements(in pLimit as Integer, in pLevel as Integer
 				-- notation (e.g. file pointers displayed as 1.4e+14 instead of
 				-- the full value).
 				if the floor of pArray[tKey] = pArray[tKey] then
-					format "%.0f" with pArray[tKey] into tString
+					variable tInt as Integer
+					put pArray[tKey] into tInt
+					format tInt as string into tString
 				else
 					format pArray[tKey] as string into tString
 				end if

--- a/extensions/widgets/treeview/treeview.lcb
+++ b/extensions/widgets/treeview/treeview.lcb
@@ -1935,7 +1935,14 @@ private handler calculateMoreElements(in pLimit as Integer, in pLevel as Integer
 			else if pArray[tKey] is a boolean then
 				format pArray[tKey] as string into tString
 			else if pArray[tKey] is a number then
-				format pArray[tKey] as string into tString
+				-- Use integer formatting for whole numbers to avoid scientific
+				-- notation (e.g. file pointers displayed as 1.4e+14 instead of
+				-- the full value).
+				if the floor of pArray[tKey] = pArray[tKey] then
+					format "%.0f" with pArray[tKey] into tString
+				else
+					format pArray[tKey] as string into tString
+				end if
 			else if pArray[tKey] is a data then
 				if not ConvertToString(pArray[tKey], tString) then
 					put "Can't display value" into tString

--- a/extensions/widgets/treeview/treeview.lcb
+++ b/extensions/widgets/treeview/treeview.lcb
@@ -1889,6 +1889,30 @@ private handler addToListBuffer(in pAt as Integer, in pElement as Array, inout x
 	splice calculateMoreElements(kRowBuffer, tLevel, tPath, tSorted, tArray) after element pAt - 1 of xList
 end handler
 
+-- Convert a whole number to a string without scientific notation.
+-- Uses digit-by-digit extraction to avoid %g-style formatting.
+private handler IntegerToString(in pValue as Number) returns String
+	variable tDigits as String
+	variable tResult as String
+	variable tRemaining as Number
+	variable tDigit as Number
+	put "0123456789" into tDigits
+	put the floor of (abs(pValue)) into tRemaining
+	if tRemaining = 0 then
+		return "0"
+	end if
+	put "" into tResult
+	repeat while tRemaining >= 1
+		put the floor of (tRemaining mod 10) into tDigit
+		put char (tDigit + 1) of tDigits & tResult into tResult
+		put the floor of (tRemaining / 10) into tRemaining
+	end repeat
+	if pValue < 0 then
+		return "-" & tResult
+	end if
+	return tResult
+end handler
+
 private handler calculateMoreElements(in pLimit as Integer, in pLevel as Integer, in pPath as List, in pSortedKeys as List, in pArray as Array) returns List
 	variable tKey as String
 	variable tElement as Array
@@ -1939,9 +1963,7 @@ private handler calculateMoreElements(in pLimit as Integer, in pLevel as Integer
 				-- notation (e.g. file pointers displayed as 1.4e+14 instead of
 				-- the full value).
 				if the floor of pArray[tKey] = pArray[tKey] then
-					variable tInt as Integer
-					put pArray[tKey] into tInt
-					format tInt as string into tString
+					put IntegerToString(pArray[tKey]) into tString
 				else
 					format pArray[tKey] as string into tString
 				end if

--- a/extensions/widgets/treeview/treeview.lcb
+++ b/extensions/widgets/treeview/treeview.lcb
@@ -1897,7 +1897,7 @@ private handler IntegerToString(in pValue as Number) returns String
 	variable tRemaining as Number
 	variable tDigit as Number
 	put "0123456789" into tDigits
-	put the floor of (abs(pValue)) into tRemaining
+	put the floor of (the abs of pValue) into tRemaining
 	if tRemaining = 0 then
 		return "0"
 	end if


### PR DESCRIPTION
Fix: Large integers displayed in scientific notation in treeview

When displaying large numbers in the IDE's array inspector, the treeview widget was converting them using LCB's format as string, which uses %g-style formatting internally and switches to scientific notation for large values (e.g. 140234567890123 displayed as 1.40235e+14). The underlying value was always stored correctly — this was purely a display issue.

The fix adds a private IntegerToString handler that detects whole numbers and converts them digit-by-digit using modulo arithmetic, bypassing the formatter entirely. Genuine floating-point values still use the original format as string path.