### PR TITLE
[[Issue 431]] Fix widget export crash

### DIFF
--- a/engine/src/widget.cpp
+++ b/engine/src/widget.cpp
@@ -1121,8 +1121,9 @@ void MCWidget::GetState(MCExecContext& ctxt, MCArrayRef& r_state)
     }
     else
     {
-        if (!MCWidgetOnSave(m_widget,
-                            &t_value))
+        if (!MCWidgetOnSave(m_widget, &t_value) || 
+            // A widget might not have an OnSave handler (e.g. colorswatch widget)
+            (*t_value == nil))
         {
             r_state = MCValueRetain(kMCEmptyArray);
             return;


### PR DESCRIPTION
Check for missing `OnSave` handler caused crash when exporting a widget to an array.

Closes #431 