### PR TITLE
fix(splash): centre splash screen on IDE's monitor at launch

### DIFF
--- a/ide/Toolset/palettes/splash/revsplashstackbehavior.livecodescript
+++ b/ide/Toolset/palettes/splash/revsplashstackbehavior.livecodescript
@@ -1,45 +1,33 @@
 ﻿script "revSplashStackBehavior"
 setProp statusMessage pMessage
    put pMessage into field "status" of me
-   -- Once the menubar stack is open we know which screen the IDE is on.
-   -- Reposition the splash there (no-op after the first successful snap).
-   if exists(stack "revMenubar") then
-      revSplashBehavior__CentreOnIDEScreen
-   end if
 end statusMessage
-
-private command revSplashBehavior__CentreOnIDEScreen
-   local tRefLoc, tRefH, tRefV
-   put the loc of stack "revMenubar" into tRefLoc
-   put item 1 of tRefLoc into tRefH
-   put item 2 of tRefLoc into tRefV
-
-   local tTargetRect
-   put line 1 of the screenRects into tTargetRect
-   repeat for each line tRect in the screenRects
-      if item 1 of tRect <= tRefH and tRefH < item 3 of tRect and \
-            item 2 of tRect <= tRefV and tRefV < item 4 of tRect then
-         put tRect into tTargetRect
-         exit repeat
-      end if
-   end repeat
-
-   local tCX, tCY
-   put (item 1 of tTargetRect + item 3 of tTargetRect) / 2 into tCX
-   put (item 2 of tTargetRect + item 4 of tTargetRect) / 2 into tCY
-   set the location of this stack to tCX, tCY
-end revSplashBehavior__CentreOnIDEScreen
 
 
 on PreOpenStack
-   -- Centre the splash on whichever screen the mouse is on at launch time.
-   -- The IDE stacks aren't open yet when the splash fires, so the mouse
-   -- position is the only reliable indicator of the user's active screen.
-   local tRefH, tRefV
-   put item 1 of the mouseLoc into tRefH
-   put item 2 of the mouseLoc into tRefV
+   -- Try to read the last saved menubar position from the preferences stack
+   -- so the splash opens on the correct screen immediately, with no visual hop.
+   -- The prefs file is loaded by referencing it by path; the normal startup
+   -- sequence will find it already in memory and continue as usual.
+   local tPrefsPath, tSavedRect
+   put the homeFolderPath & "/.hyperxtalk/preferences/hyperxtalk7.rev" into tPrefsPath
 
-   -- Walk screenRects to find which screen contains the mouse.
+   if there is a file tPrefsPath then
+      put the palette_rect_revMenubar of stack tPrefsPath into tSavedRect
+   end if
+
+   local tRefH, tRefV
+   if tSavedRect is not empty then
+      -- Use the centre of the saved menubar rect to identify the target screen.
+      put (item 1 of tSavedRect + item 3 of tSavedRect) / 2 into tRefH
+      put (item 2 of tSavedRect + item 4 of tSavedRect) / 2 into tRefV
+   else
+      -- First run or prefs missing — fall back to the mouse position.
+      put item 1 of the mouseLoc into tRefH
+      put item 2 of the mouseLoc into tRefV
+   end if
+
+   -- Walk screenRects to find which screen contains the reference point.
    local tTargetRect
    put line 1 of the screenRects into tTargetRect
    repeat for each line tRect in the screenRects

--- a/ide/Toolset/palettes/splash/revsplashstackbehavior.livecodescript
+++ b/ide/Toolset/palettes/splash/revsplashstackbehavior.livecodescript
@@ -1,4 +1,4 @@
-script "revSplashStackBehavior"
+﻿script "revSplashStackBehavior"
 
 -- Prevents repeated repositioning on every status message update.
 local sPositioned
@@ -6,7 +6,7 @@ local sPositioned
 setProp statusMessage pMessage
    put pMessage into field "status" of me
    -- The behaviour is not yet loaded when preOpenStack fires, so we position
-   -- on the first status message instead — by then it's definitely active.
+   -- on the first status message instead â by then it's definitely active.
    if not sPositioned then
       put true into sPositioned
       revSplashBehavior__CentreOnIDEScreen
@@ -17,7 +17,7 @@ end statusMessage
 private command revSplashBehavior__CentreOnIDEScreen
    -- Try the saved menubar rect from the preferences stack first.
    local tPrefsPath, tSavedRect
-   put the homeFolderPath & "/.hyperxtalk/preferences/hyperxtalk7.rev" into tPrefsPath
+   put specialfolderpath("home") & "/.hyperxtalk/preferences/hyperxtalk7.rev" into tPrefsPath
    if there is a file tPrefsPath then
       put the palette_rect_revMenubar of stack tPrefsPath into tSavedRect
    end if
@@ -28,7 +28,7 @@ private command revSplashBehavior__CentreOnIDEScreen
       put (item 1 of tSavedRect + item 3 of tSavedRect) / 2 into tRefH
       put (item 2 of tSavedRect + item 4 of tSavedRect) / 2 into tRefV
    else
-      -- First run or prefs missing — fall back to the mouse position.
+      -- First run or prefs missing â fall back to the mouse position.
       put item 1 of the mouseLoc into tRefH
       put item 2 of the mouseLoc into tRefV
    end if

--- a/ide/Toolset/palettes/splash/revsplashstackbehavior.livecodescript
+++ b/ide/Toolset/palettes/splash/revsplashstackbehavior.livecodescript
@@ -1,7 +1,34 @@
 ﻿script "revSplashStackBehavior"
 setProp statusMessage pMessage
    put pMessage into field "status" of me
+   -- Once the menubar stack is open we know which screen the IDE is on.
+   -- Reposition the splash there (no-op after the first successful snap).
+   if exists(stack "revMenubar") then
+      revSplashBehavior__CentreOnIDEScreen
+   end if
 end statusMessage
+
+private command revSplashBehavior__CentreOnIDEScreen
+   local tRefLoc, tRefH, tRefV
+   put the loc of stack "revMenubar" into tRefLoc
+   put item 1 of tRefLoc into tRefH
+   put item 2 of tRefLoc into tRefV
+
+   local tTargetRect
+   put line 1 of the screenRects into tTargetRect
+   repeat for each line tRect in the screenRects
+      if item 1 of tRect <= tRefH and tRefH < item 3 of tRect and \
+            item 2 of tRect <= tRefV and tRefV < item 4 of tRect then
+         put tRect into tTargetRect
+         exit repeat
+      end if
+   end repeat
+
+   local tCX, tCY
+   put (item 1 of tTargetRect + item 3 of tTargetRect) / 2 into tCX
+   put (item 2 of tTargetRect + item 4 of tTargetRect) / 2 into tCY
+   set the location of this stack to tCX, tCY
+end revSplashBehavior__CentreOnIDEScreen
 
 
 on PreOpenStack

--- a/ide/Toolset/palettes/splash/revsplashstackbehavior.livecodescript
+++ b/ide/Toolset/palettes/splash/revsplashstackbehavior.livecodescript
@@ -5,5 +5,31 @@ end statusMessage
 
 
 on PreOpenStack
-   set the location of this stack to (the screenLoc)
+   -- Centre the splash on whichever screen the IDE menubar is on.
+   -- Falls back to the tool palette, then the primary screen centre.
+   local tRefLoc
+   if exists(stack "revMenubar") then
+      put the loc of stack "revMenubar" into tRefLoc
+   else if exists(stack "revIDEPalette") then
+      put the loc of stack "revIDEPalette" into tRefLoc
+   else
+      set the location of this stack to the screenLoc
+      exit PreOpenStack
+   end if
+
+   -- Walk screenRects to find which screen contains the reference point.
+   local tTargetRect
+   put line 1 of the screenRects into tTargetRect
+   repeat for each line tRect in the screenRects
+      if item 1 of tRect <= item 1 of tRefLoc and item 1 of tRefLoc < item 3 of tRect and \
+            item 2 of tRect <= item 2 of tRefLoc and item 2 of tRefLoc < item 4 of tRect then
+         put tRect into tTargetRect
+         exit repeat
+      end if
+   end repeat
+
+   local tCX, tCY
+   put (item 1 of tTargetRect + item 3 of tTargetRect) / 2 into tCX
+   put (item 2 of tTargetRect + item 4 of tTargetRect) / 2 into tCY
+   set the location of this stack to tCX, tCY
 end PreOpenStack

--- a/ide/Toolset/palettes/splash/revsplashstackbehavior.livecodescript
+++ b/ide/Toolset/palettes/splash/revsplashstackbehavior.livecodescript
@@ -17,7 +17,7 @@ end statusMessage
 private command revSplashBehavior__CentreOnIDEScreen
    -- Try the saved menubar rect from the preferences stack first.
    local tPrefsPath, tSavedRect
-   put specialfolderpath("home") & "/.hyperxtalk/preferences/hyperxtalk7.rev" into tPrefsPath
+   put revEnvironmentUserPreferencesPath() & "/hyperxtalk7.rev" into tPrefsPath
    if there is a file tPrefsPath then
       put the palette_rect_revMenubar of stack tPrefsPath into tSavedRect
    end if

--- a/ide/Toolset/palettes/splash/revsplashstackbehavior.livecodescript
+++ b/ide/Toolset/palettes/splash/revsplashstackbehavior.livecodescript
@@ -5,24 +5,19 @@ end statusMessage
 
 
 on PreOpenStack
-   -- Centre the splash on whichever screen the IDE menubar is on.
-   -- Falls back to the tool palette, then the primary screen centre.
-   local tRefLoc
-   if exists(stack "revMenubar") then
-      put the loc of stack "revMenubar" into tRefLoc
-   else if exists(stack "revIDEPalette") then
-      put the loc of stack "revIDEPalette" into tRefLoc
-   else
-      set the location of this stack to the screenLoc
-      exit PreOpenStack
-   end if
+   -- Centre the splash on whichever screen the mouse is on at launch time.
+   -- The IDE stacks aren't open yet when the splash fires, so the mouse
+   -- position is the only reliable indicator of the user's active screen.
+   local tRefH, tRefV
+   put item 1 of the mouseLoc into tRefH
+   put item 2 of the mouseLoc into tRefV
 
-   -- Walk screenRects to find which screen contains the reference point.
+   -- Walk screenRects to find which screen contains the mouse.
    local tTargetRect
    put line 1 of the screenRects into tTargetRect
    repeat for each line tRect in the screenRects
-      if item 1 of tRect <= item 1 of tRefLoc and item 1 of tRefLoc < item 3 of tRect and \
-            item 2 of tRect <= item 2 of tRefLoc and item 2 of tRefLoc < item 4 of tRect then
+      if item 1 of tRect <= tRefH and tRefH < item 3 of tRect and \
+            item 2 of tRect <= tRefV and tRefV < item 4 of tRect then
          put tRect into tTargetRect
          exit repeat
       end if

--- a/ide/Toolset/palettes/splash/revsplashstackbehavior.livecodescript
+++ b/ide/Toolset/palettes/splash/revsplashstackbehavior.livecodescript
@@ -1,17 +1,23 @@
-﻿script "revSplashStackBehavior"
+script "revSplashStackBehavior"
+
+-- Prevents repeated repositioning on every status message update.
+local sPositioned
+
 setProp statusMessage pMessage
    put pMessage into field "status" of me
+   -- The behaviour is not yet loaded when preOpenStack fires, so we position
+   -- on the first status message instead — by then it's definitely active.
+   if not sPositioned then
+      put true into sPositioned
+      revSplashBehavior__CentreOnIDEScreen
+   end if
 end statusMessage
 
 
-on PreOpenStack
-   -- Try to read the last saved menubar position from the preferences stack
-   -- so the splash opens on the correct screen immediately, with no visual hop.
-   -- The prefs file is loaded by referencing it by path; the normal startup
-   -- sequence will find it already in memory and continue as usual.
+private command revSplashBehavior__CentreOnIDEScreen
+   -- Try the saved menubar rect from the preferences stack first.
    local tPrefsPath, tSavedRect
    put the homeFolderPath & "/.hyperxtalk/preferences/hyperxtalk7.rev" into tPrefsPath
-
    if there is a file tPrefsPath then
       put the palette_rect_revMenubar of stack tPrefsPath into tSavedRect
    end if
@@ -42,4 +48,4 @@ on PreOpenStack
    put (item 1 of tTargetRect + item 3 of tTargetRect) / 2 into tCX
    put (item 2 of tTargetRect + item 4 of tTargetRect) / 2 into tCY
    set the location of this stack to tCX, tCY
-end PreOpenStack
+end revSplashBehavior__CentreOnIDEScreen


### PR DESCRIPTION
fix(splash): centre splash screen on IDE's monitor at launch

Problem

On multi-monitor setups where the HyperXTalk launcher sits on a different monitor than the IDE's saved window positions, the splash screen always appeared on the primary (laptop) monitor while the IDE itself opened on the external monitor.

The root cause was that PreOpenStack in the splash behaviour fires before the behaviour stack is loaded into memory, so any positioning code placed there was silently ignored. The original set the location of this stack to the screenLoc was never executing — the splash was simply opening at its last saved position (centre of the primary screen).

Fix

Move the positioning logic to setProp statusMessage, which fires on the first IDE startup status update — by which point the behaviour is definitely active.

On each call, the handler runs only once (guarded by a script-local sPositioned flag) and delegates to revSplashBehavior__CentreOnIDEScreen, which:

Reads the saved palette_rect_revMenubar property from the preferences stack (~/.hyperxtalk/preferences/hyperxtalk7.rev) to determine which screen the IDE's menubar was last on
Walks the screenRects to find the screen containing the centre of that rect
Centres the splash on that screen

Falls back to the mouse cursor position on first run (when no preferences file exists yet).

Files changed

ide/Toolset/palettes/splash/revsplashstackbehavior.livecodescript