### PR TITLE
Fixes to backspace key

### DIFF
--- a/ide/Toolset/palettes/script editor/behaviors/revsecommoneditorbehavior.livecodescript
+++ b/ide/Toolset/palettes/script editor/behaviors/revsecommoneditorbehavior.livecodescript
@@ -2547,6 +2547,9 @@ on backspaceKey
    local tFrom, tTo
    put word 2 of it into tFrom
    put word 4 of it into tTo
+
+   ## caret position at char 1 -> exit
+   if tTo is 0 then exit backspaceKey
    
    local tAt, tLength
    if tFrom > tTo then
@@ -2569,7 +2572,7 @@ on backspaceKey
          local tWordFound
          put false into tWordFound
          repeat with x = tTo down to 1
-            if not matchText(char x of tScript, "\s") then
+            if not matchText(char x of tScript, "\S") then -- upper case "S" instead of lower case
                put true into tWordFound
             else
                if tWordFound then


### PR DESCRIPTION
Exit when cursor at position 1 to avoid deleting trailing text.

Use upper case "S" in matchChunk to avoid deleting last word of non-empty line when deleting multiple empty lines using command-backspace

fixes #473 