### PR TITLE
Prevent hang on "/*" in if-then structs

### DIFF
--- a/ide/Toolset/palettes/script editor/behaviors/revsecommoneditorbehavior.livecodescript
+++ b/ide/Toolset/palettes/script editor/behaviors/revsecommoneditorbehavior.livecodescript
@@ -2054,6 +2054,10 @@ function autoCompleteInSlashCommentOrOutOfHandler @pScript, pLineNumber
    put slash & "*" into tSlashStart
    put "*" & slash into tSlashEnd
 
+   ## remove quoted slash-asterisks 
+   replace quote & tSlashStart & quote with quote & quote in pScript
+   replace quote & tSlashEnd & quote with quote & quote in pScript
+
    put word 2 of the selectedChunk into tSelChar
    if tSelChar is empty then
       return empty


### PR DESCRIPTION
"/*" can result in an if-then struct if Structure Control Completion is on. This fixes Using control structure completion for scripts fails if there is "/*" in an "if" struct
 #475