### PR TITLE
Fix vanishing compilation errors

### DIFF
--- a/ide/Toolset/palettes/script editor/behaviors/revseeditorbehavior.livecodescript
+++ b/ide/Toolset/palettes/script editor/behaviors/revseeditorbehavior.livecodescript
@@ -740,7 +740,6 @@ command scriptCompile pObject
       put "applied" into tState
    end if
    
-   
    send "clearErrors" to group "Errors" of the owner of me
    if tResult is empty then
       setCompilationErrors empty, pObject
@@ -749,7 +748,6 @@ command scriptCompile pObject
       setCompilationErrors line 1 of tResult, pObject
       put "error" into tState
    end if
-   
    
    seSetObjectState pObject, tState
    

--- a/ide/Toolset/palettes/script editor/behaviors/revseeditorbehavior.livecodescript
+++ b/ide/Toolset/palettes/script editor/behaviors/revseeditorbehavior.livecodescript
@@ -740,16 +740,16 @@ command scriptCompile pObject
       put "applied" into tState
    end if
    
-   if tLiveErrors then
-      send "clearErrors" to group "Errors" of the owner of me
-      if tResult is empty then
-         setCompilationErrors empty, pObject
-      else
-         send "addError compilation, line 1 of tResult, pObject" to group "Errors" of the owner of me
-         setCompilationErrors line 1 of tResult, pObject
-         put "error" into tState
-      end if
+   
+   send "clearErrors" to group "Errors" of the owner of me
+   if tResult is empty then
+      setCompilationErrors empty, pObject
+   else
+      send "addError compilation, line 1 of tResult, pObject" to group "Errors" of the owner of me
+      setCompilationErrors line 1 of tResult, pObject
+      put "error" into tState
    end if
+   
    
    seSetObjectState pObject, tState
    


### PR DESCRIPTION
fix vanishing compilation errors when "LiveError" is turned off

this fixes issue 
Compile errors are not persistent if "LiveErrors" are off
 #478

