### PR TITLE
Fix LOAD_WITH_ALTERED_SEARCH_PATH ignored on Windows due to forward-slash paths

### DIFF
--- a/ide/Toolset/libraries/revideextensionlibrary.livecodescript
+++ b/ide/Toolset/libraries/revideextensionlibrary.livecodescript
@@ -1068,7 +1068,7 @@ private command __MapCodeLibraryForIDE pFolder
          filter tCodeFolders with "*-mac*"
          break
       case "Win32"
-         filter tCodeFolders with "*-win32*"
+         filter tCodeFolders with "*-win*"
          break
       default
          filter tCodeFolders with "*-"& toLower(the platform) & "*"

--- a/libfoundation/src/system-library-w32.hpp
+++ b/libfoundation/src/system-library-w32.hpp
@@ -67,6 +67,16 @@ public:
             return false;
         }
 
+        // Normalize forward slashes to backslashes so that
+        // LOAD_WITH_ALTERED_SEARCH_PATH fires correctly. Windows only treats
+        // the path as directory-qualified (and therefore searches the DLL's own
+        // directory for its dependencies) when the path contains at least one
+        // backslash. LiveCode-style native paths use forward slashes, which
+        // causes the flag to be silently ignored and the DLL to be sought only
+        // in the standard search order (application folder, PATH, System32).
+        for (wchar_t *p = *t_wstring_path; *p != L'\0'; ++p)
+            if (*p == L'/') *p = L'\\';
+
         m_handle = LoadLibraryExW(*t_wstring_path,
                                   NULL,
                                   LOAD_WITH_ALTERED_SEARCH_PATH);

--- a/libfoundation/src/system-library-w32.hpp
+++ b/libfoundation/src/system-library-w32.hpp
@@ -74,12 +74,16 @@ public:
         // backslash. LiveCode-style native paths use forward slashes, which
         // causes the flag to be silently ignored and the DLL to be sought only
         // in the standard search order (application folder, PATH, System32).
-        for (wchar_t *p = *t_wstring_path; *p != L'\0'; ++p)
+        // operator*() returns const, so take a mutable copy to normalise in-place.
+        wchar_t *t_mutable_path = _wcsdup(reinterpret_cast<const wchar_t *>(*t_wstring_path));
+        for (wchar_t *p = t_mutable_path; p && *p; ++p)
             if (*p == L'/') *p = L'\\';
 
-        m_handle = LoadLibraryExW(*t_wstring_path,
+        m_handle = LoadLibraryExW(t_mutable_path ? t_mutable_path
+                                                  : reinterpret_cast<const wchar_t *>(*t_wstring_path),
                                   NULL,
                                   LOAD_WITH_ALTERED_SEARCH_PATH);
+        free(t_mutable_path);
         
         if (m_handle == NULL)
         {


### PR DESCRIPTION
LoadLibraryExW is called with LOAD_WITH_ALTERED_SEARCH_PATH so that Windows searches the DLL's own directory when resolving its dependencies. However, this flag is only honoured when the path contains at least one backslash — if the path uses forward slashes, Windows silently ignores the flag and falls back to the standard search order (application directory, System32, PATH).

LiveCode-style native paths use forward slashes throughout, which meant LOAD_WITH_ALTERED_SEARCH_PATH never fired. As a result, widget foreign libraries (e.g. libsearchfield.dll) could only be loaded if they were placed next to HyperXTalk.exe or on the system PATH — the engine could not find them in the widget's own code/x86_64-win/ directory.

Fix: Normalize forward slashes to backslashes in CreateWithNativePath before calling LoadLibraryExW, so the flag behaves as intended and the widget code directory is searched correctly.

Testing: Built libsearchfield.dll and installed it to widget/code/x86_64-win/ only (not copied to the application folder). Widget loads and all three callbacks (searchTextChanged, searchSubmitted, searchCancelled) fire correctly on Windows