### PR TITLE
Fix Linux native-layer XEMBED geometry after plug-added handshake

### DIFF
--- a/engine/src/native-layer-x11.cpp
+++ b/engine/src/native-layer-x11.cpp
@@ -99,6 +99,17 @@ void MCNativeLayerX11::updateInputShape()
         gdk_window_input_shape_combine_region(gtk_widget_get_window(GTK_WIDGET(m_child_window)), NULL, 0, 0);
 }
 
+/* Called by GtkSocket when the XEMBED handshake completes and the plug window
+ * is fully established.  At this point gtk_socket_get_plug_window() returns a
+ * valid GdkWindow, so we can apply the correct geometry and visibility that
+ * doAttach() could not apply earlier (the plug window didn't exist yet). */
+/*static*/ void MCNativeLayerX11::OnPlugAdded(GtkSocket * /*socket*/, gpointer user_data)
+{
+    MCNativeLayerX11 *self = reinterpret_cast<MCNativeLayerX11 *>(user_data);
+    self->doSetGeometry(self->m_rect);
+    self->doSetVisible(self->ShouldShowLayer());
+}
+
 void MCNativeLayerX11::doAttach()
 {
     if (m_socket == NULL)
@@ -106,7 +117,7 @@ void MCNativeLayerX11::doAttach()
         // Create a new GTK socket to deal with the XEMBED protocol
         GtkSocket *t_socket;
 		t_socket = GTK_SOCKET(gtk_socket_new());
-        
+
         // Create a new GTK window to hold the socket
         MCRectangle t_rect;
         t_rect = m_object->getrect();
@@ -114,32 +125,36 @@ void MCNativeLayerX11::doAttach()
         gtk_widget_set_parent_window(GTK_WIDGET(m_child_window), getStackGdkWindow());
         gtk_widget_realize(GTK_WIDGET(m_child_window));
         gdk_window_reparent(gtk_widget_get_window(GTK_WIDGET(m_child_window)), getStackGdkWindow(), t_rect.x, t_rect.y);
-        
+
         // Add the socket to the window
         gtk_container_add(GTK_CONTAINER(m_child_window), GTK_WIDGET(t_socket));
-        
+
         // The socket needs to be realised before going any further or any
         // operations on it will fail.
         gtk_widget_realize(GTK_WIDGET(t_socket));
-        
+
         // Show the socket (we'll control visibility at the window level)
         gtk_widget_show(GTK_WIDGET(t_socket));
-        
+
         // Create an empty region to act as an input mask while in edit mode
         // -- tperry 12-11-2025: GTK3 uses cairo_region_create
         m_input_shape = cairo_region_create();
 
+        // When the XEMBED handshake completes the plug window becomes valid;
+        // re-apply geometry so the plug is sized correctly.
+        g_signal_connect(t_socket, "plug-added", G_CALLBACK(OnPlugAdded), this);
+
 		// Retain a reference to the socket
 		m_socket = GTK_SOCKET(g_object_ref(G_OBJECT(t_socket)));
     }
-    
+
     // -- tperry 13-11-2025: GTK3 - gtk_socket_add_id expects ::Window (XID from global namespace)
     // m_widget_xid is x11::Window, cast to ::Window to avoid namespace conflict
     // Attach the X11 window to this socket
     if (gtk_socket_get_plug_window(m_socket) == NULL)
         gtk_socket_add_id(m_socket, (::Window)m_widget_xid);
     //fprintf(stderr, "XID: %u\n", gtk_socket_get_id(m_socket));
-    
+
     // Act as if there were a re-layer to put the widget in the right place
     doRelayer();
     doSetViewportGeometry(m_viewport_rect);

--- a/engine/src/native-layer-x11.h
+++ b/engine/src/native-layer-x11.h
@@ -73,8 +73,12 @@ private:
     
     // Updates the input mask for the widget (used to implement edit mode)
     void updateInputShape();
-    
-	void updateContainerGeometry();
+
+    void updateContainerGeometry();
+
+    // GtkSocket "plug-added" signal callback — fired when the XEMBED handshake
+    // completes so we can apply the correct size to the now-valid plug window.
+    static void OnPlugAdded(GtkSocket *socket, gpointer user_data);
 };
 
 #endif // ifndef __MC_NATIVE_LAYER_X11__


### PR DESCRIPTION
Problem

When a native widget is attached on Linux, doAttach() calls gtk_socket_add_id() to begin the XEMBED handshake and then immediately calls doSetGeometry(). At that point gtk_socket_get_plug_window() returns NULL — the handshake hasn't completed yet — so the branch that resizes the remote plug window is skipped. The result is that the embedded widget appears with zero size and is never visible when switching to run mode.

Fix

Connect a plug-added signal handler to the GtkSocket in doAttach(). GTK fires this signal once the XEMBED handshake is complete and the plug window is fully established. The handler re-applies doSetGeometry(m_rect) and doSetVisible(ShouldShowLayer()) at that point, when gtk_socket_get_plug_window() is guaranteed to be non-NULL and the resize of the remote window will actually take effect.

The callback is a static member of MCNativeLayerX11 so that it has access to the protected base-class members m_rect and ShouldShowLayer().

Files changed

engine/src/native-layer-x11.h — declare static void OnPlugAdded(GtkSocket*, gpointer)
engine/src/native-layer-x11.cpp — define OnPlugAdded; connect it with g_signal_connect in doAttach() before gtk_socket_add_id()